### PR TITLE
Implement core vault functionality phase 3

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -484,26 +484,41 @@ A TypeScript monitoring script provides redundancy:
 - [`test/scenarios/LowerPriorityScenarios.test.ts`](test/scenarios/LowerPriorityScenarios.test.ts) - P3: Normal operations
 - [`test/fork/`](test/fork/) - Live Arbitrum state validation
 
----
-
-### Next Steps
-
-#### Phase 3: Core Vault Implementation (NEXT)
+#### Phase 3: Core Vault Implementation (COMPLETE)
 
 **Objective:** Build the main vault contract and deposit/withdraw flow.
 
 **Deliverables:**
-- [ ] `DeltaNeutralVault.sol` - ERC-4626 vault with share accounting
-- [ ] Basic deposit flow (receive USDC, mint shares)
-- [ ] Basic withdraw flow (burn shares, return USDC)
-- [ ] `totalAssets()` calculation combining LP + hedge positions
-- [ ] Unit tests for vault operations
+- [x] `DeltaNeutralVault.sol` - ERC-4626 vault with share accounting
+- [x] Basic deposit flow (receive USDC, mint shares)
+- [x] Basic withdraw flow (burn shares, return USDC)
+- [x] `totalAssets()` calculation combining LP + hedge positions
+- [x] Unit tests for vault operations (55 tests)
 
-**Implementation Order:**
-1. Create vault contract skeleton with ERC-4626 inheritance
-2. Implement share minting/burning logic
-3. Add position value calculation stubs
-4. Write unit tests for deposit/withdraw
+**Key Files:**
+- [`contracts/core/DeltaNeutralVault.sol`](contracts/core/DeltaNeutralVault.sol) - Main ERC-4626 vault contract
+- [`contracts/test/MockERC20.sol`](contracts/test/MockERC20.sol) - Mock token for testing
+- [`test/unit/DeltaNeutralVault.test.ts`](test/unit/DeltaNeutralVault.test.ts) - Comprehensive vault tests
+
+**Features Implemented:**
+- Full ERC-4626 compliance (deposit, mint, withdraw, redeem)
+- Deposit cap enforcement
+- Pause/unpause functionality
+- Emergency unwind capability
+- Rebalance authorization (owner + controller)
+- Manager address configuration (for Phases 4-6)
+- Delta monitoring views (returning stubs for Phase 4+)
+- Fee collection and funding claim interfaces (stubs)
+
+**Architecture Decisions:**
+1. Uses OpenZeppelin v5.0 for ERC-4626, Ownable, Pausable, ReentrancyGuard
+2. Position value hooks prepared for LiquidityManager and HedgeManager integration
+3. Delta/hedge value functions return 0 until Phases 4-5 implementation
+4. Events emit placeholder values for LP/hedge values until integration
+
+---
+
+### Next Steps
 
 #### Phase 4: Liquidity Management
 

--- a/contracts/core/DeltaNeutralVault.sol
+++ b/contracts/core/DeltaNeutralVault.sol
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @title Delta Neutral Vault
+/// @notice ERC-4626 vault that deploys capital into delta-neutral yield strategy
+/// @dev Combines Uniswap v3 LP positions with GMX v2 perpetual hedging
+contract DeltaNeutralVault is ERC4626, ReentrancyGuard, Ownable, Pausable {
+    using SafeERC20 for IERC20;
+
+    // ============ Constants ============
+
+    /// @notice Precision for percentage calculations (1e18 = 100%)
+    uint256 public constant PRECISION = 1e18;
+
+    /// @notice Delta threshold for triggering rebalance (5%)
+    uint256 public constant DELTA_THRESHOLD = 5e16;
+
+    /// @notice Maximum leverage on perpetual position (3x)
+    uint256 public constant MAX_LEVERAGE = 3e18;
+
+    /// @notice Minimum hedge ratio required (80%)
+    uint256 public constant MIN_HEDGE_RATIO = 80e16;
+
+    /// @notice Emergency threshold for circuit breaker (20%)
+    uint256 public constant EMERGENCY_THRESHOLD = 20e16;
+
+    // ============ State Variables ============
+
+    /// @notice Address of the liquidity manager (to be set in Phase 4)
+    address public liquidityManager;
+
+    /// @notice Address of the hedge manager (to be set in Phase 5)
+    address public hedgeManager;
+
+    /// @notice Address of the rebalance controller (to be set in Phase 6)
+    address public rebalanceController;
+
+    /// @notice Current Uniswap v3 position token ID (0 if no position)
+    uint256 public lpTokenId;
+
+    /// @notice Timestamp of last rebalance
+    uint256 public lastRebalanceTime;
+
+    /// @notice Total fees collected (in asset terms)
+    uint256 public totalFeesCollected;
+
+    /// @notice Total funding received/paid (can be negative)
+    int256 public totalFundingReceived;
+
+    /// @notice Deposit cap (0 means no cap)
+    uint256 public depositCap;
+
+    // ============ Events ============
+
+    /// @notice Emitted when capital is deployed to strategy
+    event CapitalDeployed(uint256 assets, uint256 lpValue, uint256 hedgeValue);
+
+    /// @notice Emitted when capital is withdrawn from strategy
+    event CapitalWithdrawn(uint256 assets, uint256 lpValue, uint256 hedgeValue);
+
+    /// @notice Emitted when a rebalance is executed
+    event Rebalanced(int256 deltaBefore, int256 deltaAfter, uint256 hedgeAdjustment);
+
+    /// @notice Emitted when fees are collected
+    event FeesCollected(uint256 amount0, uint256 amount1, uint256 totalUSD);
+
+    /// @notice Emitted when funding is claimed
+    event FundingClaimed(int256 amount);
+
+    /// @notice Emitted when deposit cap is updated
+    event DepositCapUpdated(uint256 oldCap, uint256 newCap);
+
+    /// @notice Emitted when managers are updated
+    event ManagersUpdated(
+        address liquidityManager,
+        address hedgeManager,
+        address rebalanceController
+    );
+
+    // ============ Errors ============
+
+    /// @notice Thrown when deposit would exceed cap
+    error DepositCapExceeded(uint256 requested, uint256 available);
+
+    /// @notice Thrown when caller is not authorized
+    error Unauthorized(address caller);
+
+    /// @notice Thrown when position is in emergency state
+    error EmergencyState();
+
+    /// @notice Thrown when zero amount is provided
+    error ZeroAmount();
+
+    /// @notice Thrown when address is zero
+    error ZeroAddress();
+
+    // ============ Constructor ============
+
+    /// @notice Initialize the vault with USDC as the underlying asset
+    /// @param _asset Address of the underlying asset (USDC)
+    /// @param _name Name of the vault token
+    /// @param _symbol Symbol of the vault token
+    /// @param _owner Address of the vault owner
+    constructor(
+        IERC20 _asset,
+        string memory _name,
+        string memory _symbol,
+        address _owner
+    ) ERC4626(_asset) ERC20(_name, _symbol) Ownable(_owner) {
+        if (address(_asset) == address(0)) revert ZeroAddress();
+        // Note: OpenZeppelin's Ownable already validates non-zero owner
+    }
+
+    // ============ ERC-4626 Overrides ============
+
+    /// @notice Calculate total assets under management
+    /// @dev Combines idle assets + LP position value + hedge position value
+    /// @return Total assets in USDC terms
+    function totalAssets() public view override returns (uint256) {
+        uint256 idleAssets = IERC20(asset()).balanceOf(address(this));
+        uint256 lpValue = _getLPValue();
+        uint256 hedgeValue = _getHedgeValue();
+
+        return idleAssets + lpValue + hedgeValue;
+    }
+
+    /// @notice Deposit assets and receive vault shares
+    /// @dev Overridden to add deposit cap check and reentrancy protection
+    /// @param assets Amount of assets to deposit
+    /// @param receiver Address to receive vault shares
+    /// @return shares Amount of shares minted
+    function deposit(
+        uint256 assets,
+        address receiver
+    ) public override nonReentrant whenNotPaused returns (uint256 shares) {
+        if (assets == 0) revert ZeroAmount();
+
+        // Check deposit cap
+        if (depositCap > 0) {
+            uint256 totalAfterDeposit = totalAssets() + assets;
+            if (totalAfterDeposit > depositCap) {
+                uint256 available = depositCap > totalAssets() ? depositCap - totalAssets() : 0;
+                revert DepositCapExceeded(assets, available);
+            }
+        }
+
+        shares = super.deposit(assets, receiver);
+
+        // Deploy capital to strategy (to be implemented in Phase 4+)
+        _deployCapital(assets);
+    }
+
+    /// @notice Mint exact shares by depositing assets
+    /// @dev Overridden to add deposit cap check and reentrancy protection
+    /// @param shares Amount of shares to mint
+    /// @param receiver Address to receive vault shares
+    /// @return assets Amount of assets deposited
+    function mint(
+        uint256 shares,
+        address receiver
+    ) public override nonReentrant whenNotPaused returns (uint256 assets) {
+        if (shares == 0) revert ZeroAmount();
+
+        assets = previewMint(shares);
+
+        // Check deposit cap
+        if (depositCap > 0) {
+            uint256 totalAfterDeposit = totalAssets() + assets;
+            if (totalAfterDeposit > depositCap) {
+                uint256 available = depositCap > totalAssets() ? depositCap - totalAssets() : 0;
+                revert DepositCapExceeded(assets, available);
+            }
+        }
+
+        assets = super.mint(shares, receiver);
+
+        // Deploy capital to strategy
+        _deployCapital(assets);
+    }
+
+    /// @notice Withdraw exact assets by burning shares
+    /// @dev Overridden to add reentrancy protection and capital unwinding
+    /// @param assets Amount of assets to withdraw
+    /// @param receiver Address to receive assets
+    /// @param owner Address of share owner
+    /// @return shares Amount of shares burned
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public override nonReentrant returns (uint256 shares) {
+        if (assets == 0) revert ZeroAmount();
+
+        // Unwind capital from strategy before withdrawal
+        _unwindCapital(assets);
+
+        shares = super.withdraw(assets, receiver, owner);
+    }
+
+    /// @notice Redeem exact shares for assets
+    /// @dev Overridden to add reentrancy protection and capital unwinding
+    /// @param shares Amount of shares to redeem
+    /// @param receiver Address to receive assets
+    /// @param owner Address of share owner
+    /// @return assets Amount of assets received
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner
+    ) public override nonReentrant returns (uint256 assets) {
+        if (shares == 0) revert ZeroAmount();
+
+        assets = previewRedeem(shares);
+
+        // Unwind capital from strategy before redemption
+        _unwindCapital(assets);
+
+        assets = super.redeem(shares, receiver, owner);
+    }
+
+    // ============ Strategy Functions ============
+
+    /// @notice Execute rebalance to maintain delta neutrality
+    /// @dev Called by rebalance controller when delta drift exceeds threshold
+    /// @param targetHedgeSize Target size for hedge position
+    function rebalance(uint256 targetHedgeSize) external {
+        if (msg.sender != rebalanceController && msg.sender != owner()) {
+            revert Unauthorized(msg.sender);
+        }
+
+        int256 deltaBefore = getNetDelta();
+
+        // Rebalance logic will be implemented in Phase 5+6
+        _executeRebalance(targetHedgeSize);
+
+        int256 deltaAfter = getNetDelta();
+        lastRebalanceTime = block.timestamp;
+
+        emit Rebalanced(deltaBefore, deltaAfter, targetHedgeSize);
+    }
+
+    /// @notice Collect accrued fees from LP position
+    /// @dev Called periodically to harvest yield
+    function collectFees() external returns (uint256 amount0, uint256 amount1) {
+        // Fee collection will be implemented in Phase 4
+        (amount0, amount1) = _collectLPFees();
+
+        uint256 totalUSD = _calculateFeesInUSD(amount0, amount1);
+        totalFeesCollected += totalUSD;
+
+        emit FeesCollected(amount0, amount1, totalUSD);
+    }
+
+    /// @notice Claim funding payments from perpetual position
+    /// @dev Called periodically to realize funding income/expense
+    function claimFunding() external returns (int256 fundingAmount) {
+        // Funding claim will be implemented in Phase 5
+        fundingAmount = _claimHedgeFunding();
+        totalFundingReceived += fundingAmount;
+
+        emit FundingClaimed(fundingAmount);
+    }
+
+    /// @notice Compound collected yield back into strategy
+    /// @dev Reinvests fees and funding into LP + hedge
+    function compound() external {
+        // Compounding will be implemented in Phase 6
+        _compoundYield();
+    }
+
+    // ============ View Functions ============
+
+    /// @notice Get the current LP position value in USDC terms
+    /// @return value LP position value
+    function getLPValue() external view returns (uint256 value) {
+        return _getLPValue();
+    }
+
+    /// @notice Get the current hedge position value (collateral + unrealized PnL)
+    /// @return value Hedge position value in USDC
+    function getHedgeValue() external view returns (uint256 value) {
+        return _getHedgeValue();
+    }
+
+    /// @notice Get the net delta of the combined position
+    /// @dev Net delta = LP delta + hedge delta (should be ~0)
+    /// @return netDelta Net delta (positive = long, negative = short)
+    function getNetDelta() public view returns (int256 netDelta) {
+        int256 lpDelta = _getLPDelta();
+        int256 hedgeDelta = _getHedgeDelta();
+        return lpDelta + hedgeDelta;
+    }
+
+    /// @notice Get the current delta ratio (net delta / position value)
+    /// @return deltaRatio Delta as percentage of position (scaled by 1e18)
+    function getDeltaRatio() external view returns (int256 deltaRatio) {
+        uint256 total = totalAssets();
+        if (total == 0) return 0;
+
+        int256 netDelta = getNetDelta();
+        deltaRatio = (netDelta * int256(PRECISION)) / int256(total);
+    }
+
+    /// @notice Check if rebalance is needed
+    /// @return needed True if delta drift exceeds threshold
+    function rebalanceNeeded() external view returns (bool needed) {
+        int256 deltaRatio = this.getDeltaRatio();
+        int256 absRatio = deltaRatio >= 0 ? deltaRatio : -deltaRatio;
+        return uint256(absRatio) > DELTA_THRESHOLD;
+    }
+
+    /// @notice Check if position is in emergency state
+    /// @return emergency True if delta drift exceeds emergency threshold
+    function isEmergency() external view returns (bool emergency) {
+        int256 deltaRatio = this.getDeltaRatio();
+        int256 absRatio = deltaRatio >= 0 ? deltaRatio : -deltaRatio;
+        return uint256(absRatio) > EMERGENCY_THRESHOLD;
+    }
+
+    // ============ Admin Functions ============
+
+    /// @notice Set the deposit cap
+    /// @param _depositCap New deposit cap (0 for no cap)
+    function setDepositCap(uint256 _depositCap) external onlyOwner {
+        uint256 oldCap = depositCap;
+        depositCap = _depositCap;
+        emit DepositCapUpdated(oldCap, _depositCap);
+    }
+
+    /// @notice Set manager addresses
+    /// @param _liquidityManager Address of liquidity manager
+    /// @param _hedgeManager Address of hedge manager
+    /// @param _rebalanceController Address of rebalance controller
+    function setManagers(
+        address _liquidityManager,
+        address _hedgeManager,
+        address _rebalanceController
+    ) external onlyOwner {
+        liquidityManager = _liquidityManager;
+        hedgeManager = _hedgeManager;
+        rebalanceController = _rebalanceController;
+        emit ManagersUpdated(_liquidityManager, _hedgeManager, _rebalanceController);
+    }
+
+    /// @notice Pause the vault (emergency)
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpause the vault
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Emergency unwind all positions
+    /// @dev Closes LP and hedge positions, converts everything to USDC
+    function emergencyUnwind() external onlyOwner {
+        _pause();
+        _emergencyUnwind();
+    }
+
+    // ============ Internal Functions ============
+
+    /// @notice Deploy capital to the delta-neutral strategy
+    /// @dev To be implemented in Phase 4+5 with LP and hedge integration
+    /// @param assets Amount of assets to deploy
+    function _deployCapital(uint256 assets) internal {
+        // Phase 3: No-op, assets remain idle
+        // Phase 4+: Will deploy to Uniswap v3 LP position
+        // Phase 5+: Will also open hedge on GMX v2
+
+        emit CapitalDeployed(assets, 0, 0);
+    }
+
+    /// @notice Unwind capital from strategy for withdrawal
+    /// @dev To be implemented in Phase 4+5 with LP and hedge integration
+    /// @param assets Amount of assets to unwind
+    function _unwindCapital(uint256 assets) internal {
+        // Phase 3: No-op, assets are already idle
+        // Phase 4+: Will remove liquidity from Uniswap v3
+        // Phase 5+: Will also close proportional hedge
+
+        emit CapitalWithdrawn(assets, 0, 0);
+    }
+
+    /// @notice Get LP position value
+    /// @dev To be implemented in Phase 4 with LiquidityManager
+    function _getLPValue() internal view returns (uint256) {
+        // Phase 3: Return 0 (no LP position yet)
+        // Phase 4+: Query LiquidityManager for position value
+        return 0;
+    }
+
+    /// @notice Get hedge position value
+    /// @dev To be implemented in Phase 5 with HedgeManager
+    function _getHedgeValue() internal view returns (uint256) {
+        // Phase 3: Return 0 (no hedge position yet)
+        // Phase 5+: Query HedgeManager for position value
+        return 0;
+    }
+
+    /// @notice Get LP position delta
+    /// @dev To be implemented in Phase 4 with LiquidityManager
+    function _getLPDelta() internal view returns (int256) {
+        // Phase 3: Return 0 (no LP position yet)
+        // Phase 4+: Calculate using DeltaCalculator
+        return 0;
+    }
+
+    /// @notice Get hedge position delta (negative for shorts)
+    /// @dev To be implemented in Phase 5 with HedgeManager
+    function _getHedgeDelta() internal view returns (int256) {
+        // Phase 3: Return 0 (no hedge position yet)
+        // Phase 5+: Query HedgeManager for short position size
+        return 0;
+    }
+
+    /// @notice Execute rebalance
+    /// @dev To be implemented in Phase 5+6
+    function _executeRebalance(uint256 targetHedgeSize) internal {
+        // Phase 3: No-op
+        // Phase 5+6: Adjust hedge position to match LP delta
+        (targetHedgeSize);
+    }
+
+    /// @notice Collect LP fees
+    /// @dev To be implemented in Phase 4
+    function _collectLPFees() internal returns (uint256, uint256) {
+        // Phase 3: Return 0
+        // Phase 4+: Call LiquidityManager.collectFees()
+        return (0, 0);
+    }
+
+    /// @notice Calculate fees in USD
+    /// @dev To be implemented in Phase 4
+    function _calculateFeesInUSD(uint256 amount0, uint256 amount1) internal pure returns (uint256) {
+        // Phase 3: Return 0
+        // Phase 4+: Use price oracle to convert
+        (amount0, amount1);
+        return 0;
+    }
+
+    /// @notice Claim hedge funding
+    /// @dev To be implemented in Phase 5
+    function _claimHedgeFunding() internal returns (int256) {
+        // Phase 3: Return 0
+        // Phase 5+: Call HedgeManager.claimFunding()
+        return 0;
+    }
+
+    /// @notice Compound yield
+    /// @dev To be implemented in Phase 6
+    function _compoundYield() internal {
+        // Phase 3: No-op
+        // Phase 6+: Reinvest fees and funding
+    }
+
+    /// @notice Emergency unwind all positions
+    /// @dev To be implemented in Phase 5+6
+    function _emergencyUnwind() internal {
+        // Phase 3: No-op (no positions to unwind)
+        // Phase 4+: Close LP position
+        // Phase 5+: Close hedge position
+    }
+}

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title Mock ERC20 Token
+/// @notice Simple ERC20 token for testing purposes
+contract MockERC20 is ERC20 {
+    uint8 private _decimals;
+
+    constructor(string memory name, string memory symbol, uint8 decimals_) ERC20(name, symbol) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -49,14 +49,28 @@ const testDir = process.env.TEST_SCOPE || "test";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.19",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+          viaIR: true,
+        },
       },
-      viaIR: true,
-    },
+      {
+        version: "0.8.19",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+          viaIR: true,
+        },
+      },
+    ],
   },
   paths: {
     tests: `./${testDir}`,

--- a/test/unit/DeltaNeutralVault.test.ts
+++ b/test/unit/DeltaNeutralVault.test.ts
@@ -1,0 +1,659 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { DeltaNeutralVault, MockERC20 } from "../../typechain-types";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+describe("DeltaNeutralVault", function () {
+  // Constants
+  const PRECISION = BigInt(10) ** BigInt(18);
+  const USDC_DECIMALS = 6;
+  const INITIAL_BALANCE = BigInt(1_000_000) * BigInt(10) ** BigInt(USDC_DECIMALS); // 1M USDC
+
+  // Fixture to deploy vault and mock token
+  async function deployVaultFixture() {
+    const [owner, user1, user2, rebalanceController] = await ethers.getSigners();
+
+    // Deploy mock USDC
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const usdc = await MockERC20.deploy("USD Coin", "USDC", USDC_DECIMALS);
+    await usdc.waitForDeployment();
+
+    // Mint initial USDC to users
+    await usdc.mint(owner.address, INITIAL_BALANCE);
+    await usdc.mint(user1.address, INITIAL_BALANCE);
+    await usdc.mint(user2.address, INITIAL_BALANCE);
+
+    // Deploy vault
+    const DeltaNeutralVault = await ethers.getContractFactory("DeltaNeutralVault");
+    const vault = await DeltaNeutralVault.deploy(
+      await usdc.getAddress(),
+      "Harmonia Delta Neutral",
+      "hdnUSDC",
+      owner.address
+    );
+    await vault.waitForDeployment();
+
+    // Approve vault to spend USDC
+    await usdc.connect(owner).approve(await vault.getAddress(), ethers.MaxUint256);
+    await usdc.connect(user1).approve(await vault.getAddress(), ethers.MaxUint256);
+    await usdc.connect(user2).approve(await vault.getAddress(), ethers.MaxUint256);
+
+    return { vault, usdc, owner, user1, user2, rebalanceController };
+  }
+
+  describe("Deployment", function () {
+    it("should deploy with correct parameters", async function () {
+      const { vault, usdc, owner } = await loadFixture(deployVaultFixture);
+
+      expect(await vault.name()).to.equal("Harmonia Delta Neutral");
+      expect(await vault.symbol()).to.equal("hdnUSDC");
+      expect(await vault.asset()).to.equal(await usdc.getAddress());
+      expect(await vault.owner()).to.equal(owner.address);
+      expect(await vault.totalAssets()).to.equal(0n);
+    });
+
+    it("should have correct constants", async function () {
+      const { vault } = await loadFixture(deployVaultFixture);
+
+      expect(await vault.PRECISION()).to.equal(PRECISION);
+      expect(await vault.DELTA_THRESHOLD()).to.equal((5n * PRECISION) / 100n); // 5%
+      expect(await vault.MAX_LEVERAGE()).to.equal(3n * PRECISION); // 3x
+      expect(await vault.MIN_HEDGE_RATIO()).to.equal((80n * PRECISION) / 100n); // 80%
+      expect(await vault.EMERGENCY_THRESHOLD()).to.equal((20n * PRECISION) / 100n); // 20%
+    });
+
+    it("should revert on zero asset address", async function () {
+      const [owner] = await ethers.getSigners();
+      const DeltaNeutralVault = await ethers.getContractFactory("DeltaNeutralVault");
+
+      await expect(
+        DeltaNeutralVault.deploy(ethers.ZeroAddress, "Test", "TEST", owner.address)
+      ).to.be.revertedWithCustomError(DeltaNeutralVault, "ZeroAddress");
+    });
+
+    it("should revert on zero owner address", async function () {
+      const { usdc } = await loadFixture(deployVaultFixture);
+      const DeltaNeutralVault = await ethers.getContractFactory("DeltaNeutralVault");
+
+      // OpenZeppelin's Ownable throws OwnableInvalidOwner for zero address
+      await expect(
+        DeltaNeutralVault.deploy(await usdc.getAddress(), "Test", "TEST", ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(DeltaNeutralVault, "OwnableInvalidOwner");
+    });
+  });
+
+  describe("Deposit", function () {
+    it("should accept deposits and mint shares", async function () {
+      const { vault, usdc, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      const sharesBefore = await vault.balanceOf(user1.address);
+      expect(sharesBefore).to.equal(0n);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      const sharesAfter = await vault.balanceOf(user1.address);
+      expect(sharesAfter).to.be.gt(0n);
+      expect(await vault.totalAssets()).to.equal(depositAmount);
+    });
+
+    it("should mint correct shares based on exchange rate", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      // First deposit - 1:1 ratio
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+      const shares1 = await vault.balanceOf(user1.address);
+
+      // Shares should equal assets for initial deposit (with decimal adjustment)
+      expect(shares1).to.equal(depositAmount);
+    });
+
+    it("should emit CapitalDeployed event", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await expect(vault.connect(user1).deposit(depositAmount, user1.address))
+        .to.emit(vault, "CapitalDeployed")
+        .withArgs(depositAmount, 0n, 0n); // LP and hedge values are 0 in Phase 3
+    });
+
+    it("should revert on zero amount deposit", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+
+      await expect(vault.connect(user1).deposit(0n, user1.address)).to.be.revertedWithCustomError(
+        vault,
+        "ZeroAmount"
+      );
+    });
+
+    it("should respect deposit cap", async function () {
+      const { vault, owner, user1 } = await loadFixture(deployVaultFixture);
+      const depositCap = BigInt(50_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const depositAmount = BigInt(60_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(owner).setDepositCap(depositCap);
+
+      await expect(vault.connect(user1).deposit(depositAmount, user1.address))
+        .to.be.revertedWithCustomError(vault, "DepositCapExceeded")
+        .withArgs(depositAmount, depositCap);
+    });
+
+    it("should allow deposit up to cap", async function () {
+      const { vault, owner, user1 } = await loadFixture(deployVaultFixture);
+      const depositCap = BigInt(50_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(owner).setDepositCap(depositCap);
+      await vault.connect(user1).deposit(depositCap, user1.address);
+
+      expect(await vault.totalAssets()).to.equal(depositCap);
+    });
+
+    it("should revert when paused", async function () {
+      const { vault, owner, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(owner).pause();
+
+      await expect(
+        vault.connect(user1).deposit(depositAmount, user1.address)
+      ).to.be.revertedWithCustomError(vault, "EnforcedPause");
+    });
+  });
+
+  describe("Mint", function () {
+    it("should mint exact shares", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const sharesToMint = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).mint(sharesToMint, user1.address);
+
+      expect(await vault.balanceOf(user1.address)).to.equal(sharesToMint);
+    });
+
+    it("should revert on zero shares mint", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+
+      await expect(vault.connect(user1).mint(0n, user1.address)).to.be.revertedWithCustomError(
+        vault,
+        "ZeroAmount"
+      );
+    });
+
+    it("should respect deposit cap when minting", async function () {
+      const { vault, owner, user1 } = await loadFixture(deployVaultFixture);
+      const depositCap = BigInt(50_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const sharesToMint = BigInt(60_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(owner).setDepositCap(depositCap);
+
+      await expect(
+        vault.connect(user1).mint(sharesToMint, user1.address)
+      ).to.be.revertedWithCustomError(vault, "DepositCapExceeded");
+    });
+  });
+
+  describe("Withdraw", function () {
+    it("should allow withdrawal of deposited assets", async function () {
+      const { vault, usdc, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      const balanceBefore = await usdc.balanceOf(user1.address);
+      await vault.connect(user1).withdraw(depositAmount, user1.address, user1.address);
+      const balanceAfter = await usdc.balanceOf(user1.address);
+
+      expect(balanceAfter - balanceBefore).to.equal(depositAmount);
+      expect(await vault.balanceOf(user1.address)).to.equal(0n);
+    });
+
+    it("should emit CapitalWithdrawn event", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(vault.connect(user1).withdraw(depositAmount, user1.address, user1.address))
+        .to.emit(vault, "CapitalWithdrawn")
+        .withArgs(depositAmount, 0n, 0n);
+    });
+
+    it("should allow partial withdrawal", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const withdrawAmount = BigInt(5_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+      await vault.connect(user1).withdraw(withdrawAmount, user1.address, user1.address);
+
+      expect(await vault.totalAssets()).to.equal(depositAmount - withdrawAmount);
+    });
+
+    it("should revert on zero amount withdrawal", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(
+        vault.connect(user1).withdraw(0n, user1.address, user1.address)
+      ).to.be.revertedWithCustomError(vault, "ZeroAmount");
+    });
+
+    it("should revert when withdrawing more than balance", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const withdrawAmount = BigInt(20_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(vault.connect(user1).withdraw(withdrawAmount, user1.address, user1.address)).to
+        .be.reverted;
+    });
+  });
+
+  describe("Redeem", function () {
+    it("should redeem shares for assets", async function () {
+      const { vault, usdc, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+      const shares = await vault.balanceOf(user1.address);
+
+      const balanceBefore = await usdc.balanceOf(user1.address);
+      await vault.connect(user1).redeem(shares, user1.address, user1.address);
+      const balanceAfter = await usdc.balanceOf(user1.address);
+
+      expect(balanceAfter - balanceBefore).to.equal(depositAmount);
+    });
+
+    it("should revert on zero shares redeem", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(
+        vault.connect(user1).redeem(0n, user1.address, user1.address)
+      ).to.be.revertedWithCustomError(vault, "ZeroAmount");
+    });
+  });
+
+  describe("Multiple Users", function () {
+    it("should handle multiple depositors correctly", async function () {
+      const { vault, user1, user2 } = await loadFixture(deployVaultFixture);
+      const deposit1 = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const deposit2 = BigInt(20_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(deposit1, user1.address);
+      await vault.connect(user2).deposit(deposit2, user2.address);
+
+      expect(await vault.totalAssets()).to.equal(deposit1 + deposit2);
+      expect(await vault.balanceOf(user1.address)).to.be.gt(0n);
+      expect(await vault.balanceOf(user2.address)).to.be.gt(0n);
+    });
+
+    it("should maintain correct share ratios", async function () {
+      const { vault, user1, user2 } = await loadFixture(deployVaultFixture);
+      const deposit1 = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const deposit2 = BigInt(20_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(deposit1, user1.address);
+      await vault.connect(user2).deposit(deposit2, user2.address);
+
+      const shares1 = await vault.balanceOf(user1.address);
+      const shares2 = await vault.balanceOf(user2.address);
+
+      // User2 should have 2x the shares (deposited 2x the amount)
+      expect(shares2).to.equal(shares1 * 2n);
+    });
+  });
+
+  describe("Total Assets", function () {
+    it("should return correct total assets after deposits", async function () {
+      const { vault, user1, user2 } = await loadFixture(deployVaultFixture);
+      const deposit1 = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const deposit2 = BigInt(5_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(deposit1, user1.address);
+      expect(await vault.totalAssets()).to.equal(deposit1);
+
+      await vault.connect(user2).deposit(deposit2, user2.address);
+      expect(await vault.totalAssets()).to.equal(deposit1 + deposit2);
+    });
+
+    it("should return correct total assets after withdrawals", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+      const withdrawAmount = BigInt(3_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+      await vault.connect(user1).withdraw(withdrawAmount, user1.address, user1.address);
+
+      expect(await vault.totalAssets()).to.equal(depositAmount - withdrawAmount);
+    });
+  });
+
+  describe("View Functions", function () {
+    it("should return 0 for LP value in Phase 3", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      expect(await vault.getLPValue()).to.equal(0n);
+    });
+
+    it("should return 0 for hedge value in Phase 3", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      expect(await vault.getHedgeValue()).to.equal(0n);
+    });
+
+    it("should return 0 for net delta in Phase 3", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      expect(await vault.getNetDelta()).to.equal(0n);
+    });
+
+    it("should return 0 for delta ratio in Phase 3", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      expect(await vault.getDeltaRatio()).to.equal(0n);
+    });
+
+    it("should not need rebalance in Phase 3", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      expect(await vault.rebalanceNeeded()).to.equal(false);
+    });
+
+    it("should not be in emergency in Phase 3", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      expect(await vault.isEmergency()).to.equal(false);
+    });
+  });
+
+  describe("Admin Functions", function () {
+    describe("setDepositCap", function () {
+      it("should allow owner to set deposit cap", async function () {
+        const { vault, owner } = await loadFixture(deployVaultFixture);
+        const newCap = BigInt(100_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+        await vault.connect(owner).setDepositCap(newCap);
+
+        expect(await vault.depositCap()).to.equal(newCap);
+      });
+
+      it("should emit DepositCapUpdated event", async function () {
+        const { vault, owner } = await loadFixture(deployVaultFixture);
+        const newCap = BigInt(100_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+        await expect(vault.connect(owner).setDepositCap(newCap))
+          .to.emit(vault, "DepositCapUpdated")
+          .withArgs(0n, newCap);
+      });
+
+      it("should reject non-owner setting deposit cap", async function () {
+        const { vault, user1 } = await loadFixture(deployVaultFixture);
+        const newCap = BigInt(100_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+        await expect(vault.connect(user1).setDepositCap(newCap)).to.be.revertedWithCustomError(
+          vault,
+          "OwnableUnauthorizedAccount"
+        );
+      });
+    });
+
+    describe("setManagers", function () {
+      it("should allow owner to set managers", async function () {
+        const { vault, owner, rebalanceController } = await loadFixture(deployVaultFixture);
+        const liquidityManager = ethers.Wallet.createRandom().address;
+        const hedgeManager = ethers.Wallet.createRandom().address;
+
+        await vault
+          .connect(owner)
+          .setManagers(liquidityManager, hedgeManager, rebalanceController.address);
+
+        expect(await vault.liquidityManager()).to.equal(liquidityManager);
+        expect(await vault.hedgeManager()).to.equal(hedgeManager);
+        expect(await vault.rebalanceController()).to.equal(rebalanceController.address);
+      });
+
+      it("should emit ManagersUpdated event", async function () {
+        const { vault, owner, rebalanceController } = await loadFixture(deployVaultFixture);
+        const liquidityManager = ethers.Wallet.createRandom().address;
+        const hedgeManager = ethers.Wallet.createRandom().address;
+
+        await expect(
+          vault
+            .connect(owner)
+            .setManagers(liquidityManager, hedgeManager, rebalanceController.address)
+        )
+          .to.emit(vault, "ManagersUpdated")
+          .withArgs(liquidityManager, hedgeManager, rebalanceController.address);
+      });
+
+      it("should reject non-owner setting managers", async function () {
+        const { vault, user1, rebalanceController } = await loadFixture(deployVaultFixture);
+        const liquidityManager = ethers.Wallet.createRandom().address;
+        const hedgeManager = ethers.Wallet.createRandom().address;
+
+        await expect(
+          vault
+            .connect(user1)
+            .setManagers(liquidityManager, hedgeManager, rebalanceController.address)
+        ).to.be.revertedWithCustomError(vault, "OwnableUnauthorizedAccount");
+      });
+    });
+
+    describe("pause/unpause", function () {
+      it("should allow owner to pause", async function () {
+        const { vault, owner } = await loadFixture(deployVaultFixture);
+
+        await vault.connect(owner).pause();
+
+        expect(await vault.paused()).to.equal(true);
+      });
+
+      it("should allow owner to unpause", async function () {
+        const { vault, owner } = await loadFixture(deployVaultFixture);
+
+        await vault.connect(owner).pause();
+        await vault.connect(owner).unpause();
+
+        expect(await vault.paused()).to.equal(false);
+      });
+
+      it("should reject non-owner pause", async function () {
+        const { vault, user1 } = await loadFixture(deployVaultFixture);
+
+        await expect(vault.connect(user1).pause()).to.be.revertedWithCustomError(
+          vault,
+          "OwnableUnauthorizedAccount"
+        );
+      });
+    });
+
+    describe("emergencyUnwind", function () {
+      it("should pause vault on emergency unwind", async function () {
+        const { vault, owner } = await loadFixture(deployVaultFixture);
+
+        await vault.connect(owner).emergencyUnwind();
+
+        expect(await vault.paused()).to.equal(true);
+      });
+
+      it("should reject non-owner emergency unwind", async function () {
+        const { vault, user1 } = await loadFixture(deployVaultFixture);
+
+        await expect(vault.connect(user1).emergencyUnwind()).to.be.revertedWithCustomError(
+          vault,
+          "OwnableUnauthorizedAccount"
+        );
+      });
+    });
+  });
+
+  describe("Rebalance", function () {
+    it("should allow owner to rebalance", async function () {
+      const { vault, owner, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(vault.connect(owner).rebalance(1000n)).to.emit(vault, "Rebalanced");
+    });
+
+    it("should allow rebalance controller to rebalance", async function () {
+      const { vault, owner, user1, rebalanceController } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+      await vault
+        .connect(owner)
+        .setManagers(ethers.ZeroAddress, ethers.ZeroAddress, rebalanceController.address);
+
+      await expect(vault.connect(rebalanceController).rebalance(1000n)).to.emit(
+        vault,
+        "Rebalanced"
+      );
+    });
+
+    it("should reject unauthorized rebalance", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(vault.connect(user1).rebalance(1000n)).to.be.revertedWithCustomError(
+        vault,
+        "Unauthorized"
+      );
+    });
+
+    it("should update lastRebalanceTime", async function () {
+      const { vault, owner, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      const timeBefore = await vault.lastRebalanceTime();
+      expect(timeBefore).to.equal(0n);
+
+      await vault.connect(owner).rebalance(1000n);
+
+      const timeAfter = await vault.lastRebalanceTime();
+      expect(timeAfter).to.be.gt(0n);
+    });
+  });
+
+  describe("Fee Collection", function () {
+    it("should emit FeesCollected event (with zero values in Phase 3)", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(vault.collectFees()).to.emit(vault, "FeesCollected").withArgs(0n, 0n, 0n);
+    });
+  });
+
+  describe("Funding Claims", function () {
+    it("should emit FundingClaimed event (with zero value in Phase 3)", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      await expect(vault.claimFunding()).to.emit(vault, "FundingClaimed").withArgs(0n);
+    });
+  });
+
+  describe("ERC-4626 Preview Functions", function () {
+    it("should preview deposit correctly", async function () {
+      const { vault } = await loadFixture(deployVaultFixture);
+      const assets = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      const shares = await vault.previewDeposit(assets);
+      expect(shares).to.equal(assets); // 1:1 for initial deposit
+    });
+
+    it("should preview mint correctly", async function () {
+      const { vault } = await loadFixture(deployVaultFixture);
+      const shares = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      const assets = await vault.previewMint(shares);
+      expect(assets).to.equal(shares); // 1:1 for initial mint
+    });
+
+    it("should preview withdraw correctly", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      const shares = await vault.previewWithdraw(depositAmount);
+      expect(shares).to.equal(depositAmount);
+    });
+
+    it("should preview redeem correctly", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+      const shares = await vault.balanceOf(user1.address);
+
+      const assets = await vault.previewRedeem(shares);
+      expect(assets).to.equal(depositAmount);
+    });
+  });
+
+  describe("Max Deposit/Mint/Withdraw/Redeem", function () {
+    it("should return max deposit without cap", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+
+      const maxDeposit = await vault.maxDeposit(user1.address);
+      expect(maxDeposit).to.equal(ethers.MaxUint256);
+    });
+
+    it("should return max withdraw", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+
+      const maxWithdraw = await vault.maxWithdraw(user1.address);
+      expect(maxWithdraw).to.equal(depositAmount);
+    });
+
+    it("should return max redeem", async function () {
+      const { vault, user1 } = await loadFixture(deployVaultFixture);
+      const depositAmount = BigInt(10_000) * BigInt(10) ** BigInt(USDC_DECIMALS);
+
+      await vault.connect(user1).deposit(depositAmount, user1.address);
+      const shares = await vault.balanceOf(user1.address);
+
+      const maxRedeem = await vault.maxRedeem(user1.address);
+      expect(maxRedeem).to.equal(shares);
+    });
+  });
+});


### PR DESCRIPTION
Add the main vault contract with full ERC-4626 compliance:

- DeltaNeutralVault.sol: ERC-4626 vault accepting USDC deposits
  - deposit/mint: Receive USDC and mint vault shares
  - withdraw/redeem: Burn shares and return USDC
  - totalAssets(): Calculate total vault value (idle + LP + hedge stubs)
  - Deposit cap enforcement with DepositCapExceeded error
  - Pause/unpause and emergency unwind functionality
  - Rebalance authorization for owner and controller
  - Manager address configuration hooks for Phases 4-6
  - Delta monitoring views (getNetDelta, getDeltaRatio, etc.)
  - Fee collection and funding claim interfaces (stubs)

- MockERC20.sol: Test token with configurable decimals

- 55 comprehensive unit tests covering:
  - ERC-4626 deposit/mint/withdraw/redeem flows
  - Share accounting and exchange rate calculations
  - Multi-user scenarios and share ratios
  - Admin functions (deposit cap, managers, pause)
  - Rebalance authorization
  - View functions returning Phase 3 stubs

- Updated hardhat.config.ts for OpenZeppelin v5.0 compatibility (added 0.8.20 compiler alongside 0.8.19)

- Updated PLAN.md roadmap marking Phase 3 complete

All 126 tests pass (55 vault + 71 existing).