### PR TITLE
feat: calculate and display LP position values in monitor script

### DIFF
--- a/scripts/monitor-position.ts
+++ b/scripts/monitor-position.ts
@@ -3,6 +3,8 @@ import { ARBITRUM_MAINNET } from "../src/config/addresses";
 import { DeltaNeutralMonitor } from "../src/strategy/monitor";
 import { StrategyAction } from "../src/strategy/types";
 import { loadStrategyConfig } from "../src/config/strategy";
+import { getAmountsForLiquidity, getSqrtRatioAtTick } from "../src/modules/math/ticks";
+import * as uniswapReader from "../src/modules/uniswap/reader";
 
 async function main() {
   const [signer] = await ethers.getSigners();
@@ -37,17 +39,94 @@ async function main() {
   try {
     const { status, recommendation } = await monitor.check();
 
+    // Get pool contract to determine token order and decimals
+    const poolContract = uniswapReader.createPool(context.uniswap.pool, ethers.provider);
+    const poolToken0 = await poolContract.token0();
+    const poolToken1 = await poolContract.token1();
+
+    const ERC20_ABI = [
+      "function decimals() view returns (uint8)",
+      "function symbol() view returns (string)",
+    ];
+    const token0Contract = new ethers.Contract(poolToken0, ERC20_ABI, ethers.provider);
+    const token1Contract = new ethers.Contract(poolToken1, ERC20_ABI, ethers.provider);
+    const [decimals0, decimals1, symbol0, symbol1] = await Promise.all([
+      token0Contract.decimals(),
+      token1Contract.decimals(),
+      token0Contract.symbol(),
+      token1Contract.symbol(),
+    ]);
+
+    // Determine which token is collateral (stable) vs risk
+    const isToken0Collateral =
+      poolToken0.toLowerCase() === context.gmx.collateralToken.toLowerCase();
+    const riskTokenDecimals = isToken0Collateral ? decimals1 : decimals0;
+    const stableDecimals = isToken0Collateral ? decimals0 : decimals1;
+    const riskSymbol = isToken0Collateral ? symbol1 : symbol0;
+    const stableSymbol = isToken0Collateral ? symbol0 : symbol1;
+
+    // Get current risk token price (from first position's currentPrice)
+    const riskTokenPrice = status.uniswap.length > 0 ? status.uniswap[0].currentPrice : 0;
+
+    // Helper function to convert token amount to USD (30 decimals)
+    const calculateUsdValue = (amount: bigint, decimals: number, price: number): bigint => {
+      if (amount === 0n) return 0n;
+      const sign = amount < 0n ? -1n : 1n;
+      const absAmount = amount < 0n ? -amount : amount;
+      const amountStr = ethers.formatUnits(absAmount, decimals);
+      const amountFloat = parseFloat(amountStr);
+      const usdFloat = amountFloat * price;
+      try {
+        return sign * ethers.parseUnits(usdFloat.toFixed(18), 30);
+      } catch (e) {
+        return sign * BigInt(Math.floor(usdFloat * 1e30));
+      }
+    };
+
     console.log(`\n[Uniswap Positions] (${status.uniswap.length} active)`);
     let totalFees0 = 0n;
     let totalFees1 = 0n;
+    let totalLpValueUsd = 0n;
 
     for (const pos of status.uniswap) {
+      // Calculate token amounts from liquidity
+      const sqrtPriceAX96 = getSqrtRatioAtTick(pos.tickLower);
+      const sqrtPriceBX96 = getSqrtRatioAtTick(pos.tickUpper);
+      const { amount0, amount1 } = getAmountsForLiquidity(
+        pos.sqrtPriceX96,
+        sqrtPriceAX96,
+        sqrtPriceBX96,
+        pos.liquidity
+      );
+
+      // Calculate USD value of this position
+
+      let positionValueUsd = 0n;
+      if (isToken0Collateral) {
+        // Token0 is stable (USDC), Token1 is risk (ETH)
+        // Stable token is $1, risk token is at riskTokenPrice
+        const stableValue = calculateUsdValue(amount0, Number(decimals0), 1.0);
+        const riskValue = calculateUsdValue(amount1, Number(decimals1), riskTokenPrice);
+        positionValueUsd = stableValue + riskValue;
+      } else {
+        // Token0 is risk (ETH), Token1 is stable (USDC)
+        // Risk token is at riskTokenPrice, stable token is $1
+        const riskValue = calculateUsdValue(amount0, Number(decimals0), riskTokenPrice);
+        const stableValue = calculateUsdValue(amount1, Number(decimals1), 1.0);
+        positionValueUsd = riskValue + stableValue;
+      }
+      totalLpValueUsd += positionValueUsd;
+
       console.log(`  > Token ID: ${pos.tokenId}`);
       console.log(
         `    Price Range: [${pos.priceLower.toFixed(6)}, ${pos.priceUpper.toFixed(6)}] ${pos.priceLabel} (Current: ${pos.currentPrice.toFixed(6)})`
       );
       console.log(`    Zone: ${pos.delta.zone}`);
       console.log(`    Delta: ${ethers.formatEther(pos.delta.delta)} ETH`);
+      console.log(
+        `    Token Amounts: ${ethers.formatUnits(amount0, Number(decimals0))} ${symbol0}, ${ethers.formatUnits(amount1, Number(decimals1))} ${symbol1}`
+      );
+      console.log(`    Position Value: $${ethers.formatUnits(positionValueUsd, 30)}`);
       console.log(
         `    Fees: ${ethers.formatEther(pos.unclaimedFees.amount0)} ETH, ${ethers.formatUnits(pos.unclaimedFees.amount1, 6)} USDC`
       );
@@ -57,6 +136,7 @@ async function main() {
 
     console.log("\n[Uniswap Aggregated]");
     console.log(`  Total LP Delta: ${ethers.formatEther(status.totalLpDelta)} ETH`);
+    console.log(`  Total LP Value: $${ethers.formatUnits(totalLpValueUsd, 30)}`);
     console.log(
       `  Total Unclaimed Fees: ${ethers.formatEther(totalFees0)} ETH, ${ethers.formatUnits(totalFees1, 6)} USDC`
     );
@@ -70,6 +150,13 @@ async function main() {
     console.log("\n[Net Strategy]");
     console.log(`  Net Delta: ${ethers.formatEther(status.netDelta)} ETH`);
     console.log(`  Delta Drift: ${(status.deltaDrift * 100).toFixed(2)}%`);
+
+    // Calculate and display total net value
+    const totalNetValueUsd = totalLpValueUsd + status.gmx.netValueUsd;
+    console.log(`\n[Total Portfolio Value]`);
+    console.log(`  LP Positions: $${ethers.formatUnits(totalLpValueUsd, 30)}`);
+    console.log(`  GMX Position: $${ethers.formatUnits(status.gmx.netValueUsd, 30)}`);
+    console.log(`  Total Net Value: $${ethers.formatUnits(totalNetValueUsd, 30)}`);
 
     console.log("\n[Recommendation]");
     const color = recommendation.action === StrategyAction.NONE ? "\x1b[32m" : "\x1b[33m"; // Green for NONE, Yellow for others


### PR DESCRIPTION
This PR adds functionality to calculate and display the current dollar value of LP positions in the monitor-position script.

## Changes
- Calculate current dollar value of each LP position using token amounts from liquidity
- Display individual position values with token amounts for each position
- Show total LP value in the aggregated section
- Combine LP value with GMX net value to show total portfolio value at the end

## Implementation Details
- Uses `getAmountsForLiquidity` to calculate token0 and token1 amounts for each position
- Converts token amounts to USD using current prices (stable token = $1, risk token = current market price)
- All values displayed in USD with 30 decimals to match GMX's format
- Handles both token order scenarios (token0 as collateral vs token1 as collateral)