### PR TITLE
feat: add collected fees 24h to daily report

### DIFF
--- a/src/cli/commands/daemon-impl.ts
+++ b/src/cli/commands/daemon-impl.ts
@@ -177,6 +177,11 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
         logger.warn("Failed to fetch APR metrics for report", { error });
       }
 
+      // Get collected fees for last 24h
+      const now = Date.now();
+      const oneDayAgo = now - 24 * 60 * 60 * 1000;
+      const collectedFees24h = db.getFeesCollected(account, oneDayAgo, now);
+
       // Generate report
       const report = generateDailyReport(
         account,
@@ -185,7 +190,8 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
         totalLpValueUsd,
         totalFeesUsd,
         aprMetricsData,
-        walletBalances
+        walletBalances,
+        collectedFees24h
       );
 
       // Save report to file

--- a/src/cli/commands/report-impl.ts
+++ b/src/cli/commands/report-impl.ts
@@ -146,6 +146,8 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
   // Get APR metrics
   const db = new MonitoringDatabase();
   let aprMetricsData: { apr1d?: number; apr7d?: number; apr30d?: number } = {};
+  let collectedFees24h = 0n;
+
   try {
     const metrics = await getAPRMetrics(db, account);
     aprMetricsData = {
@@ -153,8 +155,13 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
       apr7d: metrics.rolling7d?.aprPercent,
       apr30d: metrics.rolling30d?.aprPercent,
     };
+
+    // Get collected fees for last 24h
+    const now = Date.now();
+    const oneDayAgo = now - 24 * 60 * 60 * 1000;
+    collectedFees24h = db.getFeesCollected(account, oneDayAgo, now);
   } catch (error) {
-    logger.warn("Failed to fetch APR metrics for report", { error });
+    logger.warn("Failed to fetch APR metrics or collected fees for report", { error });
   } finally {
     db.close();
   }
@@ -167,7 +174,8 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
     totalLpValueUsd,
     totalFeesUsd,
     aprMetricsData,
-    walletBalances
+    walletBalances,
+    collectedFees24h
   );
 
   // Override date if specified
@@ -203,6 +211,9 @@ export function generateDiscordSummary(report: DailyReport): {
   const totalNetValue = parseFloat(report.summary.totalNetValueUsd);
   const deltaDriftPercent = report.summary.deltaDrift * 100;
   const feesUsd = parseFloat(report.metrics.totalFeesUsd);
+  const collectedFees24hUsd = report.metrics.collectedFees24h
+    ? parseFloat(report.metrics.collectedFees24h)
+    : 0;
 
   // Determine status emoji based on health
   let statusEmoji = "✅";
@@ -232,6 +243,14 @@ export function generateDiscordSummary(report: DailyReport): {
       inline: true,
     },
   ];
+
+  if (collectedFees24hUsd > 0) {
+    fields.push({
+      name: "Collected Fees (24h)",
+      value: `$${collectedFees24hUsd.toFixed(4)}`,
+      inline: true,
+    });
+  }
 
   if (
     report.metrics.apr1d !== undefined ||

--- a/src/utils/reports.ts
+++ b/src/utils/reports.ts
@@ -45,7 +45,8 @@ export interface DailyReport {
   };
   metrics: {
     totalLpDelta: string;
-    totalFeesUsd: string;
+    totalFeesUsd: string; // Unclaimed fees
+    collectedFees24h?: string; // Fees collected in last 24h
     deltaDriftPercent: number;
     apr1d?: number;
     apr7d?: number;
@@ -70,7 +71,8 @@ export function generateDailyReport(
   walletBalances?: {
     balance0: string;
     balance1: string;
-  }
+  },
+  collectedFees24h?: bigint
 ): DailyReport {
   const totalNetValueUsd = totalLpValueUsd + status.gmx.netValueUsd;
 
@@ -111,6 +113,7 @@ export function generateDailyReport(
     metrics: {
       totalLpDelta: ethers.formatEther(status.totalLpDelta),
       totalFeesUsd: ethers.formatUnits(totalFeesUsd, 30),
+      collectedFees24h: collectedFees24h ? ethers.formatUnits(collectedFees24h, 30) : undefined,
       deltaDriftPercent: status.deltaDrift * 100,
       apr1d: aprMetrics?.apr1d,
       apr7d: aprMetrics?.apr7d,
@@ -239,7 +242,10 @@ export function formatReportSummary(report: DailyReport): string {
   lines.push("METRICS");
   lines.push("-".repeat(80));
   lines.push(`Total LP Delta: ${report.metrics.totalLpDelta} ETH`);
-  lines.push(`Total Fees USD: $${report.metrics.totalFeesUsd}`);
+  lines.push(`Total Fees USD: $${report.metrics.totalFeesUsd} (Unclaimed)`);
+  if (report.metrics.collectedFees24h) {
+    lines.push(`Collected Fees (24h): $${report.metrics.collectedFees24h}`);
+  }
   lines.push(`Delta Drift: ${report.metrics.deltaDriftPercent.toFixed(2)}%`);
 
   if (

--- a/test/cli/commands/report.test.ts
+++ b/test/cli/commands/report.test.ts
@@ -92,7 +92,7 @@ vi.mock("../../../src/modules/uniswap/reader", () => ({
 }));
 
 vi.mock("../../../src/utils/reports", () => ({
-  generateDailyReport: vi.fn((account, status, recommendation, totalLpValueUsd, totalFeesUsd, aprMetrics, walletBalances) => ({
+  generateDailyReport: vi.fn((account, status, recommendation, totalLpValueUsd, totalFeesUsd, aprMetrics, walletBalances, collectedFees24h) => ({
     date: new Date().toISOString().split("T")[0],
     timestamp: Date.now(),
     account,
@@ -118,6 +118,7 @@ vi.mock("../../../src/utils/reports", () => ({
     metrics: {
       totalLpDelta: "1.0",
       totalFeesUsd: "10.0",
+      collectedFees24h: collectedFees24h ? collectedFees24h.toString() : undefined,
       deltaDriftPercent: 0,
       apr1d: aprMetrics?.apr1d,
       apr7d: aprMetrics?.apr7d,
@@ -247,5 +248,44 @@ describe("Report Implementation", () => {
     expect(summary.fields[4].name).toBe("Wallet Balances");
     expect(summary.fields[4].value).toContain("1.5 WETH");
     expect(summary.fields[4].value).toContain("2000.0 USDC");
+  });
+
+  it("should include collected fees in Discord summary when present", async () => {
+    const { generateDiscordSummary } = await import("../../../src/cli/commands/report-impl");
+    
+    const report = {
+      date: "2026-01-26",
+      timestamp: Date.now(),
+      account: "0x1234567890123456789012345678901234567890",
+      summary: {
+        totalLpValueUsd: "1000.0",
+        totalGmxValueUsd: "500.0",
+        totalNetValueUsd: "1500.0",
+        netDelta: "0.0",
+        deltaDrift: 0,
+        recommendation: "NONE",
+      },
+      positions: {
+        uniswap: [],
+        gmx: {
+          positionSizeTokens: "1.0",
+          collateralAmount: "500.0",
+          netValueUsd: "500.0",
+          delta: "-1.0",
+        },
+      },
+      metrics: {
+        totalLpDelta: "0.0",
+        totalFeesUsd: "10.0",
+        collectedFees24h: "5.50",
+        deltaDriftPercent: 0,
+      },
+    };
+
+    const summary = generateDiscordSummary(report as any);
+    
+    const collectedFeesField = summary.fields.find(f => f.name === "Collected Fees (24h)");
+    expect(collectedFeesField).toBeDefined();
+    expect(collectedFeesField?.value).toBe("$5.5000");
   });
 });


### PR DESCRIPTION
This PR adds a new metric to the daily report and Discord summary: the sum of fees collected in the last 24 hours.

Changes:
- Updated `DailyReport` interface and generation logic.
- Updated `report` command and `daemon` to query 24h collected fees from the database.
- Updated Discord summary to display the new metric.
- Added tests for the new functionality.