### PR TITLE
feat: replace collected fees 24h with net yield 24h in daily report

### DIFF
--- a/src/cli/commands/report-impl.ts
+++ b/src/cli/commands/report-impl.ts
@@ -146,7 +146,7 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
   // Get APR metrics
   const db = new MonitoringDatabase();
   let aprMetricsData: { apr1d?: number; apr7d?: number; apr30d?: number } = {};
-  let collectedFees24h = 0n;
+  let netYield24h = 0n;
 
   try {
     const metrics = await getAPRMetrics(db, account);
@@ -156,12 +156,14 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
       apr30d: metrics.rolling30d?.aprPercent,
     };
 
-    // Get collected fees for last 24h
+    // Get net yield for last 24h (fees collected - costs incurred)
     const now = Date.now();
     const oneDayAgo = now - 24 * 60 * 60 * 1000;
-    collectedFees24h = db.getFeesCollected(account, oneDayAgo, now);
+    const feesCollected24h = db.getFeesCollected(account, oneDayAgo, now);
+    const costsIncurred24h = db.getTotalCosts(account, oneDayAgo, now);
+    netYield24h = feesCollected24h - costsIncurred24h;
   } catch (error) {
-    logger.warn("Failed to fetch APR metrics or collected fees for report", { error });
+    logger.warn("Failed to fetch APR metrics or net yield for report", { error });
   } finally {
     db.close();
   }
@@ -175,7 +177,7 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
     totalFeesUsd,
     aprMetricsData,
     walletBalances,
-    collectedFees24h
+    netYield24h
   );
 
   // Override date if specified
@@ -211,9 +213,7 @@ export function generateDiscordSummary(report: DailyReport): {
   const totalNetValue = parseFloat(report.summary.totalNetValueUsd);
   const deltaDriftPercent = report.summary.deltaDrift * 100;
   const feesUsd = parseFloat(report.metrics.totalFeesUsd);
-  const collectedFees24hUsd = report.metrics.collectedFees24h
-    ? parseFloat(report.metrics.collectedFees24h)
-    : 0;
+  const netYield24hUsd = report.metrics.netYield24h ? parseFloat(report.metrics.netYield24h) : 0;
 
   // Determine status emoji based on health
   let statusEmoji = "✅";
@@ -244,10 +244,10 @@ export function generateDiscordSummary(report: DailyReport): {
     },
   ];
 
-  if (collectedFees24hUsd > 0) {
+  if (Math.abs(netYield24hUsd) > 0) {
     fields.push({
-      name: "Collected Fees (24h)",
-      value: `$${collectedFees24hUsd.toFixed(4)}`,
+      name: "Net Yield (24h)",
+      value: `$${netYield24hUsd.toFixed(4)}`,
       inline: true,
     });
   }

--- a/src/utils/reports.ts
+++ b/src/utils/reports.ts
@@ -46,7 +46,7 @@ export interface DailyReport {
   metrics: {
     totalLpDelta: string;
     totalFeesUsd: string; // Unclaimed fees
-    collectedFees24h?: string; // Fees collected in last 24h
+    netYield24h?: string; // Net yield in last 24h
     deltaDriftPercent: number;
     apr1d?: number;
     apr7d?: number;
@@ -72,7 +72,7 @@ export function generateDailyReport(
     balance0: string;
     balance1: string;
   },
-  collectedFees24h?: bigint
+  netYield24h?: bigint
 ): DailyReport {
   const totalNetValueUsd = totalLpValueUsd + status.gmx.netValueUsd;
 
@@ -113,7 +113,7 @@ export function generateDailyReport(
     metrics: {
       totalLpDelta: ethers.formatEther(status.totalLpDelta),
       totalFeesUsd: ethers.formatUnits(totalFeesUsd, 30),
-      collectedFees24h: collectedFees24h ? ethers.formatUnits(collectedFees24h, 30) : undefined,
+      netYield24h: netYield24h ? ethers.formatUnits(netYield24h, 30) : undefined,
       deltaDriftPercent: status.deltaDrift * 100,
       apr1d: aprMetrics?.apr1d,
       apr7d: aprMetrics?.apr7d,
@@ -243,8 +243,8 @@ export function formatReportSummary(report: DailyReport): string {
   lines.push("-".repeat(80));
   lines.push(`Total LP Delta: ${report.metrics.totalLpDelta} ETH`);
   lines.push(`Total Fees USD: $${report.metrics.totalFeesUsd} (Unclaimed)`);
-  if (report.metrics.collectedFees24h) {
-    lines.push(`Collected Fees (24h): $${report.metrics.collectedFees24h}`);
+  if (report.metrics.netYield24h) {
+    lines.push(`Net Yield (24h): $${report.metrics.netYield24h}`);
   }
   lines.push(`Delta Drift: ${report.metrics.deltaDriftPercent.toFixed(2)}%`);
 

--- a/test/cli/commands/report.test.ts
+++ b/test/cli/commands/report.test.ts
@@ -92,7 +92,7 @@ vi.mock("../../../src/modules/uniswap/reader", () => ({
 }));
 
 vi.mock("../../../src/utils/reports", () => ({
-  generateDailyReport: vi.fn((account, status, recommendation, totalLpValueUsd, totalFeesUsd, aprMetrics, walletBalances, collectedFees24h) => ({
+  generateDailyReport: vi.fn((account, status, recommendation, totalLpValueUsd, totalFeesUsd, aprMetrics, walletBalances, netYield24h) => ({
     date: new Date().toISOString().split("T")[0],
     timestamp: Date.now(),
     account,
@@ -118,7 +118,7 @@ vi.mock("../../../src/utils/reports", () => ({
     metrics: {
       totalLpDelta: "1.0",
       totalFeesUsd: "10.0",
-      collectedFees24h: collectedFees24h ? collectedFees24h.toString() : undefined,
+      netYield24h: netYield24h ? netYield24h.toString() : undefined,
       deltaDriftPercent: 0,
       apr1d: aprMetrics?.apr1d,
       apr7d: aprMetrics?.apr7d,
@@ -250,7 +250,7 @@ describe("Report Implementation", () => {
     expect(summary.fields[4].value).toContain("2000.0 USDC");
   });
 
-  it("should include collected fees in Discord summary when present", async () => {
+  it("should include net yield in Discord summary when present", async () => {
     const { generateDiscordSummary } = await import("../../../src/cli/commands/report-impl");
     
     const report = {
@@ -277,15 +277,15 @@ describe("Report Implementation", () => {
       metrics: {
         totalLpDelta: "0.0",
         totalFeesUsd: "10.0",
-        collectedFees24h: "5.50",
+        netYield24h: "5.50",
         deltaDriftPercent: 0,
       },
     };
 
     const summary = generateDiscordSummary(report as any);
     
-    const collectedFeesField = summary.fields.find(f => f.name === "Collected Fees (24h)");
-    expect(collectedFeesField).toBeDefined();
-    expect(collectedFeesField?.value).toBe("$5.5000");
+    const netYieldField = summary.fields.find(f => f.name === "Net Yield (24h)");
+    expect(netYieldField).toBeDefined();
+    expect(netYieldField?.value).toBe("$5.5000");
   });
 });


### PR DESCRIPTION
Updates the daily report to show the 24-hour Net Yield (fees collected - costs incurred) instead of just the gross fees collected. This provides a more accurate view of daily profitability.