### PR TITLE
fix(db): resolve sqlite integer overflow in APR calculations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ npm test              # Run all tests once
 npm run test:watch    # Run tests in watch mode
 ```
 
+**Note:** Always use `npm test` (or `npm run test:watch`) to run tests. Do not use `npx vitest` directly, as it requires manual intervention to complete.
+
 **Test Requirements:**
 - ✅ **All tests must pass** - Never commit code with failing tests
 - ✅ **Comprehensive coverage** - Write tests for all new functionality

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -950,8 +950,9 @@ export class MonitoringDatabase {
    * Get total fees collected in a time period
    */
   getFeesCollected(account: string, startTime?: number, endTime?: number): bigint {
+    // Fetch individual rows and sum in JS to avoid SQLite integer overflow
     let query = `
-      SELECT SUM(CAST(fees_collected_usd AS TEXT)) as total
+      SELECT fees_collected_usd
       FROM fee_collection_history
       WHERE account = ?
     `;
@@ -968,9 +969,18 @@ export class MonitoringDatabase {
     }
 
     const stmt = this.db.prepare(query);
-    const row = stmt.get(...params) as { total: string | null } | undefined;
+    const rows = stmt.all(...params) as Array<{ fees_collected_usd: string }>;
 
-    return row?.total ? BigInt(row.total) : 0n;
+    let total = 0n;
+    for (const row of rows) {
+      try {
+        total += BigInt(row.fees_collected_usd);
+      } catch (e) {
+        // Ignore invalid values
+      }
+    }
+
+    return total;
   }
 
   /**
@@ -983,10 +993,11 @@ export class MonitoringDatabase {
    */
   getTotalCosts(account: string, startTime?: number, endTime?: number): bigint {
     // Get gas costs and GMX execution fees
+    // We fetch individual rows and sum in JS to avoid SQLite integer overflow
     let query = `
       SELECT 
-        SUM(CAST(gas_cost_usd AS TEXT)) as total_gas,
-        SUM(CAST(gmx_execution_fee_usd AS TEXT)) as total_gmx_fees
+        gas_cost_usd,
+        gmx_execution_fee_usd
       FROM operation_history
       WHERE account = ?
     `;
@@ -1003,19 +1014,36 @@ export class MonitoringDatabase {
     }
 
     const stmt = this.db.prepare(query);
-    const row = stmt.get(...params) as
-      | {
-          total_gas: string | null;
-          total_gmx_fees: string | null;
-        }
-      | undefined;
+    const rows = stmt.all(...params) as Array<{
+      gas_cost_usd: string | null;
+      gmx_execution_fee_usd: string | null;
+    }>;
 
-    const gasCosts = row?.total_gas ? BigInt(row.total_gas) : 0n;
-    const gmxFees = row?.total_gmx_fees ? BigInt(row.total_gmx_fees) : 0n;
+    let totalGas = 0n;
+    let totalGmxFees = 0n;
+
+    for (const row of rows) {
+      if (row.gas_cost_usd) {
+        // Handle potential huge values or garbage by wrapping in try/catch if necessary
+        // but BigInt constructor should handle valid numeric strings
+        try {
+          totalGas += BigInt(row.gas_cost_usd);
+        } catch (e) {
+          // Ignore invalid values
+        }
+      }
+      if (row.gmx_execution_fee_usd) {
+        try {
+          totalGmxFees += BigInt(row.gmx_execution_fee_usd);
+        } catch (e) {
+          // Ignore invalid values
+        }
+      }
+    }
 
     // TODO: Add funding fee calculation from snapshot deltas
     // For now, return gas costs + GMX execution fees
-    return gasCosts + gmxFees;
+    return totalGas + totalGmxFees;
   }
 
   /**

--- a/test/utils/database-overflow.test.ts
+++ b/test/utils/database-overflow.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MonitoringDatabase } from "../../src/utils/database";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("MonitoringDatabase Integer Overflow Fix", () => {
+  let db: MonitoringDatabase;
+  let testDbPath: string;
+
+  beforeEach(() => {
+    // Create a temporary database file for each test
+    testDbPath = path.join(
+      process.cwd(),
+      "test-data",
+      `test-overflow-${Date.now()}-${Math.random().toString(36).substring(7)}.db`
+    );
+    db = new MonitoringDatabase(testDbPath);
+  });
+
+  afterEach(() => {
+    // Clean up: close database and remove test file
+    db.close();
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+  });
+
+  it("should correctly sum large gas costs without integer overflow", () => {
+    const account = "0x123";
+    
+    // Use values that would definitely overflow 64-bit signed integer if summed as integers
+    // 2^63 - 1 is ~9.22 * 10^18
+    // We use 2 * 10^30
+    const hugeValue = BigInt("2000000000000000000000000000000");
+
+    db.recordOperation(account, "rebalance", hugeValue);
+    db.recordOperation(account, "rebalance", hugeValue);
+
+    const total = db.getTotalCosts(account);
+    
+    // Should be 4 * 10^30
+    const expected = hugeValue * 2n;
+    expect(total).toBe(expected);
+  });
+
+  it("should handle mixed large and small values", () => {
+    const account = "0x456";
+    const hugeValue = BigInt("2000000000000000000000000000000");
+    const smallValue = BigInt("1000");
+
+    db.recordOperation(account, "rebalance", hugeValue);
+    db.recordOperation(account, "rebalance", smallValue);
+
+    const total = db.getTotalCosts(account);
+    expect(total).toBe(hugeValue + smallValue);
+  });
+
+  it("should correctly sum large fees collected without integer overflow", () => {
+    const account = "0x789";
+    const hugeValue = BigInt("2000000000000000000000000000000");
+    
+    // fee_collection_history requires more fields: timestamp, account, token_id, fees_collected_usd
+    // We can use recordFeeCollection method if available, or insert directly if not exposed conveniently for testing raw values
+    // db.recordFeeCollection converts to string, so we can use it.
+    
+    db.recordFeeCollection(account, "token1", hugeValue);
+    db.recordFeeCollection(account, "token1", hugeValue);
+
+    const total = db.getFeesCollected(account);
+    expect(total).toBe(hugeValue * 2n);
+  });
+});


### PR DESCRIPTION
### Description
Moves the summation of gas costs, execution fees, and collected fees from the SQLite query layer to the application layer (TypeScript).

### Problem
SQLite's `SUM()` function was causing integer overflows when aggregating large integer values (Wei/USD scaled by 1e18 or 1e30) stored as strings/TEXT but cast to integers for calculation. This prevented the APR report from generating successfully.

### Solution
- Updated `getTotalCosts` and `getFeesCollected` in `src/utils/database.ts` to fetch individual rows.
- Performed summation using TypeScript's `BigInt` to handle arbitrary precision integers.
- Added regression tests in `test/utils/database-overflow.test.ts`.

### Verification
- [x] New regression tests pass.
- [x] `npm run cli -- apr` runs successfully without error.