### PR TITLE
feat(strategy): runtime-tunable LP range/buffers with DB hot reload and auto tuning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,41 +237,49 @@ npm run cli -- gmx read-position
 npm run cli -- uniswap read-position
 ```
 
-## Important Constants
+## Runtime Strategy Parameters
 
-Contract addresses and strategy parameters are defined in `src/config/`:
+Strategy config is now runtime-tunable via SQLite-backed params.
 
-**Addresses** (`src/config/addresses.ts`):
-```typescript
-import { ARBITRUM_MAINNET, STRATEGY_PARAMS } from './config/addresses';
+### Parameter precedence
 
-// Key addresses
-ARBITRUM_MAINNET.usdc              // "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
-ARBITRUM_MAINNET.weth              // "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
-ARBITRUM_MAINNET.gmxExchangeRouter // "0x1C3fa76e6E1088bCE750f23a5BFcffa1efEF6A41"
-ARBITRUM_MAINNET.uniswapV3PositionManager // "0xC36442b4a4522E871399CD717aBDD847Ab11FE88"
+1. Account runtime param override
+2. Global runtime param override
+3. Environment/default config from `src/config/strategy.ts`
 
-// Strategy parameters (BigInt values)
-STRATEGY_PARAMS.DELTA_THRESHOLD    // 5e16 (5%) - trigger rebalance
-STRATEGY_PARAMS.MAX_LEVERAGE       // 3e18 (3x) - max leverage on perps
-STRATEGY_PARAMS.MAX_SLIPPAGE       // 1e16 (1%) - slippage tolerance
-STRATEGY_PARAMS.EMERGENCY_THRESHOLD // 20e16 (20%) - emergency alert threshold
+### CLI commands
+
+```bash
+# Show effective params (account scope by default)
+npm run cli -- strategy params show --network arbitrum
+
+# Show global scope only
+npm run cli -- strategy params show --network arbitrum --global
+
+# Set runtime param (manual lock by default)
+npm run cli -- strategy params set --network arbitrum --key defaultRangeWidth --value 0.08 --reason "widen for volatility"
+
+# Set runtime param with TTL
+npm run cli -- strategy params set --network arbitrum --key hedgeDeltaThreshold --value 0.04 --ttl 3600 --reason "temporary tighter hedge"
+
+# Clear runtime param
+npm run cli -- strategy params clear --network arbitrum --key hedgeDeltaThreshold
+
+# View runtime param history
+npm run cli -- strategy params history --network arbitrum --limit 50
+
+# Enable/disable auto-tuning
+npm run cli -- strategy params auto --network arbitrum --enable
+npm run cli -- strategy params auto --network arbitrum --disable
 ```
 
-**Range Configuration** (`src/config/markets.ts` or `src/config/strategy.ts`):
-```typescript
-import { RANGE_CONFIG, getDefaultRangeBounds } from './config/range';
+### Source of truth
 
-RANGE_CONFIG.DEFAULT_RANGE_WIDTH              // 0.2 (20% total = ±10%)
-RANGE_CONFIG.MIN_RANGE_WIDTH                 // 0.1 (10% minimum = ±5%)
-RANGE_CONFIG.MAX_RANGE_WIDTH                 // 0.4 (40% maximum = ±20%)
-RANGE_CONFIG.RANGE_ADJUSTMENT_THRESHOLD      // 0.02 (2% - adjust if near edge)
-RANGE_CONFIG.RANGE_CENTER_DRIFT_THRESHOLD   // 0.05 (5% - adjust if drifted from center)
-RANGE_CONFIG.MIN_RANGE_ADJUSTMENT_INTERVAL   // 3600 (1 hour minimum)
-
-// Helper function to get default range bounds
-const bounds = getDefaultRangeBounds(currentPrice, rangeWidth);
-```
+- Contract addresses: `src/config/addresses.ts`
+- Static strategy defaults + validation: `src/config/strategy.ts`
+- Runtime merge/precedence logic: `src/strategy/runtime-config.ts`
+- Auto regime tuning: `src/strategy/auto-tuner.ts`
+- Runtime param storage + audit: `src/utils/database.ts`, `src/utils/migrations.ts`
 
 ## Documentation
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -536,6 +536,100 @@ npm run cli -- strategy monitor --network arbitrum --token-id 12345
 NETWORK=arbitrum npm run cli -- strategy monitor --token-id 12345
 ```
 
+### Optimize Position
+
+Execute full optimization (collect fees, reset LP range, update hedge):
+
+```bash
+npm run cli -- strategy optimize [options]
+```
+
+Options:
+- `--token-id <id>` - Optional Uniswap token ID
+- `--range-width <number>` - Optional explicit range width override
+- `--price-lower <number>` - Optional lower price override
+- `--price-upper <number>` - Optional upper price override
+- `--slippage-bps <number>` - Slippage tolerance (default: 50)
+- `--db-path <path>` - Runtime params DB path (default: `./data/monitoring.db`)
+- `--execute` - Actually execute transactions (default: dry-run)
+
+Notes:
+- If `--range-width` is omitted, optimize uses the **effective runtime** `defaultRangeWidth` (account/global overrides included).
+
+### Runtime Strategy Params
+
+Manage runtime-tunable strategy parameters:
+
+```bash
+npm run cli -- strategy params <subcommand> [options]
+```
+
+#### `show`
+
+Show effective runtime strategy parameters:
+
+```bash
+npm run cli -- strategy params show --network arbitrum
+npm run cli -- strategy params show --network arbitrum --global
+```
+
+Options:
+- `--global` - Show global scope only
+- `--db-path <path>` - Custom database path
+
+#### `set`
+
+Set a runtime strategy parameter (manual lock by default):
+
+```bash
+npm run cli -- strategy params set --network arbitrum --key defaultRangeWidth --value 0.08
+npm run cli -- strategy params set --network arbitrum --key hedgeDeltaThreshold --value 0.04 --ttl 3600 --reason \"temporary tighter hedge\"
+```
+
+Options:
+- `--key <key>` - Parameter key
+- `--value <value>` - Numeric value
+- `--ttl <seconds>` - Optional TTL
+- `--reason <text>` - Optional audit reason
+- `--global` - Write to global scope
+- `--db-path <path>` - Custom database path
+
+Supported runtime strategy keys:
+- `defaultRangeWidth`
+- `rangeAdjustmentThreshold`
+- `rangeCenterDriftThreshold`
+- `hedgeDeltaThreshold`
+- `optimizationDeltaThreshold`
+- `emergencyDeltaThreshold`
+- `minRangeWidth`
+- `maxRangeWidth`
+
+#### `clear`
+
+Clear a runtime parameter:
+
+```bash
+npm run cli -- strategy params clear --network arbitrum --key hedgeDeltaThreshold
+```
+
+#### `history`
+
+Query runtime parameter audit history:
+
+```bash
+npm run cli -- strategy params history --network arbitrum --limit 50
+npm run cli -- strategy params history --network arbitrum --key defaultRangeWidth
+```
+
+#### `auto`
+
+Enable/disable auto regime tuning:
+
+```bash
+npm run cli -- strategy params auto --network arbitrum --enable
+npm run cli -- strategy params auto --network arbitrum --disable
+```
+
 ## Extending the CLI
 
 The CLI is designed to be easily extensible. To add a new command:

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -8,6 +8,8 @@ The monitoring database stores:
 - **Monitoring snapshots**: Complete strategy status at each monitoring check
 - **Position snapshots**: Detailed tracking of Uniswap LP and GMX hedge positions
 - **NAV history**: Time series data for Net Asset Value tracking
+- **Runtime strategy params**: Live tunable strategy keys with global/account scope
+- **Runtime param history**: Audit trail for set/clear/expire events
 
 ## Database Location
 
@@ -90,6 +92,42 @@ Time series NAV tracking for analysis.
 
 **Unique constraint**: `(timestamp, account)` - one NAV entry per account per timestamp
 
+#### `runtime_params`
+Active runtime strategy parameters used for hot-reload configuration.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER PRIMARY KEY | Auto-incrementing ID |
+| `account` | TEXT nullable | Scope (`NULL` = global, otherwise account-specific) |
+| `param_key` | TEXT | Runtime parameter key |
+| `param_value` | TEXT | JSON-encoded value |
+| `source` | TEXT | `manual` or `auto` |
+| `is_locked` | INTEGER | Lock flag (`1` prevents auto overwrite) |
+| `updated_at` | INTEGER | Last update timestamp (ms) |
+| `expires_at` | INTEGER nullable | Optional expiration timestamp (ms) |
+| `reason` | TEXT nullable | Optional audit reason |
+| `created_at` | INTEGER | Record creation timestamp |
+
+**Unique constraint**: `(account, param_key)`
+
+#### `runtime_param_history`
+Audit trail for runtime parameter mutations.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER PRIMARY KEY | Auto-incrementing ID |
+| `timestamp` | INTEGER | Event timestamp (ms) |
+| `account` | TEXT nullable | Scope (`NULL` = global) |
+| `param_key` | TEXT | Runtime parameter key |
+| `old_value` | TEXT nullable | Previous JSON value |
+| `new_value` | TEXT nullable | New JSON value |
+| `source` | TEXT | `manual` or `auto` |
+| `action` | TEXT | `set`, `clear`, or `expire` |
+| `is_locked` | INTEGER nullable | Lock flag at event time |
+| `expires_at` | INTEGER nullable | Expiry at event time |
+| `reason` | TEXT nullable | Optional reason |
+| `created_at` | INTEGER | Record creation timestamp |
+
 #### `schema_migrations`
 Tracks applied database migrations.
 
@@ -109,6 +147,9 @@ The following indexes are created for query performance:
 - `idx_positions_token_id` on `position_snapshots(token_id)`
 - `idx_nav_history_timestamp` on `nav_history(timestamp)`
 - `idx_nav_history_account` on `nav_history(account)`
+- `idx_runtime_params_account_key` on `runtime_params(account, param_key)`
+- `idx_runtime_params_expires` on `runtime_params(expires_at)`
+- `idx_runtime_param_history_account_key_time` on `runtime_param_history(account, param_key, timestamp DESC)`
 
 ## Migrations
 
@@ -219,6 +260,16 @@ const snapshots = db.getSnapshots("0x...", startTime, endTime, limit);
 
 // Get position snapshots for a snapshot
 const positions = db.getPositionSnapshots(snapshotId);
+
+// Runtime params: set/list/clear/history
+db.setRuntimeParam("0x...", "defaultRangeWidth", 0.08, {
+  source: "manual",
+  isLocked: true,
+  reason: "widen range during volatility",
+});
+const runtimeParams = db.listRuntimeParams({ account: "0x...", includeGlobal: true });
+const history = db.listRuntimeParamHistory({ account: "0x...", limit: 50 });
+db.clearRuntimeParam("0x...", "defaultRangeWidth");
 
 db.close();
 ```

--- a/src/cli/commands/daemon-impl.ts
+++ b/src/cli/commands/daemon-impl.ts
@@ -1,7 +1,6 @@
 import { ethers } from "hardhat";
 import { ARBITRUM_MAINNET } from "../../config/addresses";
 import { DeltaNeutralMonitor } from "../../strategy/monitor";
-import { loadStrategyConfig } from "../../config/strategy";
 import { getAmountsForLiquidity, getSqrtRatioAtTick } from "../../modules/math/ticks";
 import * as uniswapReader from "../../modules/uniswap/reader";
 import { getSignerAndAccount } from "./base";
@@ -22,6 +21,8 @@ import {
 import { generateDailyReport, saveDailyReport } from "../../utils/reports";
 import { generateDiscordSummary } from "./report-impl";
 import { StrategyStatus, Recommendation } from "../../strategy/types";
+import { diffStrategyConfigs, loadEffectiveStrategyConfig } from "../../strategy/runtime-config";
+import { runAutoTuner } from "../../strategy/auto-tuner";
 
 export interface DaemonOptions {
   account?: string;
@@ -52,7 +53,7 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
   const db = new MonitoringDatabase(dbPath);
 
   // Initialize monitor
-  const config = loadStrategyConfig();
+  let effectiveConfig = loadEffectiveStrategyConfig(db, account).config;
   const context = {
     uniswap: {
       positionManager: ARBITRUM_MAINNET.uniswapV3PositionManager,
@@ -69,7 +70,7 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
     multicall3: ARBITRUM_MAINNET.multicall3,
   };
 
-  const monitorInstance = new DeltaNeutralMonitor(ethers.provider, config, context, db);
+  const monitorInstance = new DeltaNeutralMonitor(ethers.provider, effectiveConfig, context, db);
 
   // Get pool contract to determine token order and decimals
   const poolContract = uniswapReader.createPool(context.uniswap.pool, ethers.provider);
@@ -261,6 +262,41 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
         // Check if we should stop before starting a new check
         if (!isRunning) break;
 
+        // Refresh runtime config each cycle (manual overrides + account-specific values).
+        const refreshedConfig = loadEffectiveStrategyConfig(db, account).config;
+        const manualChanges = diffStrategyConfigs(effectiveConfig, refreshedConfig);
+        if (manualChanges.length > 0) {
+          effectiveConfig = refreshedConfig;
+          monitorInstance.setConfig(effectiveConfig);
+          logger.info("Applied runtime strategy config update", {
+            source: "manual-or-expiry",
+            changedKeys: manualChanges.map((change) => change.key),
+            changes: manualChanges,
+          });
+        }
+
+        // Run auto-tuner after manual refresh. If it applies updates, re-resolve effective config.
+        const autoTuneResult = runAutoTuner({
+          db,
+          account,
+          effectiveConfig,
+        });
+        if (autoTuneResult.applied) {
+          const autoTunedConfig = loadEffectiveStrategyConfig(db, account).config;
+          const autoChanges = diffStrategyConfigs(effectiveConfig, autoTunedConfig);
+          if (autoChanges.length > 0) {
+            effectiveConfig = autoTunedConfig;
+            monitorInstance.setConfig(effectiveConfig);
+            logger.info("Applied auto-tuner strategy config update", {
+              regime: autoTuneResult.regime,
+              candidateRegime: autoTuneResult.candidateRegime,
+              metrics: autoTuneResult.metrics,
+              changedKeys: autoChanges.map((change) => change.key),
+              changes: autoChanges,
+            });
+          }
+        }
+
         logger.debug("Running monitoring check", { account, timestamp: Date.now() });
 
         // Perform monitoring check
@@ -380,6 +416,8 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
               account,
               execute: true,
               suppressAlert: true,
+              strategyConfig: effectiveConfig,
+              dbPath,
             });
 
             // Optimization succeeded - reset failure counter
@@ -452,7 +490,7 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
 
             // Record successful optimization in database
             try {
-              const gasCostUsd = config.estimatedOptimizationGasCostUsd;
+              const gasCostUsd = effectiveConfig.estimatedOptimizationGasCostUsd;
               const benefitUsd = recommendation.data?.estimatedBenefitUsd || totalFeesUsd;
               db.recordOptimization(
                 account,
@@ -588,6 +626,7 @@ export async function daemon(options: DaemonOptions = {}): Promise<void> {
               execute: true,
               suppressAlert: true,
               dbPath,
+              strategyConfig: effectiveConfig,
             });
 
             consecutiveHedgeFailures = 0;

--- a/src/cli/commands/dashboard-impl.ts
+++ b/src/cli/commands/dashboard-impl.ts
@@ -2,13 +2,14 @@ import { ethers } from "hardhat";
 import { ARBITRUM_MAINNET } from "../../config/addresses";
 import { DeltaNeutralMonitor } from "../../strategy/monitor";
 import { StrategyAction } from "../../strategy/types";
-import { loadStrategyConfig } from "../../config/strategy";
 import { getAmountsForLiquidity, getSqrtRatioAtTick } from "../../modules/math/ticks";
 import * as uniswapReader from "../../modules/uniswap/reader";
 import { getSignerAndAccount } from "./base";
 import { ERC20_ABI } from "../../utils/abis";
 import { getLogger } from "../../utils/logger";
 import { generateDailyReport, saveDailyReport, formatReportSummary } from "../../utils/reports";
+import { MonitoringDatabase } from "../../utils/database";
+import { diffStrategyConfigs, loadEffectiveStrategyConfig } from "../../strategy/runtime-config";
 
 export interface DashboardOptions {
   account?: string;
@@ -243,7 +244,8 @@ export async function dashboard(options: DashboardOptions = {}): Promise<void> {
 
   logger.info("Starting dashboard", { account, refreshInterval, autoRefresh });
 
-  const config = loadStrategyConfig();
+  const runtimeDb = new MonitoringDatabase();
+  let effectiveConfig = loadEffectiveStrategyConfig(runtimeDb, account).config;
 
   const context = {
     uniswap: {
@@ -261,7 +263,7 @@ export async function dashboard(options: DashboardOptions = {}): Promise<void> {
     multicall3: ARBITRUM_MAINNET.multicall3,
   };
 
-  const monitorInstance = new DeltaNeutralMonitor(ethers.provider, config, context);
+  const monitorInstance = new DeltaNeutralMonitor(ethers.provider, effectiveConfig, context);
 
   // Get pool contract to determine token order and decimals
   const poolContract = uniswapReader.createPool(context.uniswap.pool, ethers.provider);
@@ -309,6 +311,16 @@ export async function dashboard(options: DashboardOptions = {}): Promise<void> {
 
   const updateDashboard = async () => {
     try {
+      const refreshedConfig = loadEffectiveStrategyConfig(runtimeDb, account).config;
+      const changes = diffStrategyConfigs(effectiveConfig, refreshedConfig);
+      if (changes.length > 0) {
+        effectiveConfig = refreshedConfig;
+        monitorInstance.setConfig(effectiveConfig);
+        logger.info("Dashboard applied runtime strategy config update", {
+          changedKeys: changes.map((change) => change.key),
+        });
+      }
+
       const { status, recommendation } = await monitorInstance.check();
 
       // Get current risk token price
@@ -441,6 +453,7 @@ export async function dashboard(options: DashboardOptions = {}): Promise<void> {
     // Handle graceful shutdown
     process.on("SIGINT", () => {
       clearInterval(intervalId);
+      runtimeDb.close();
       logger.info("Dashboard stopped");
       logger.close();
       clearScreen();
@@ -448,6 +461,7 @@ export async function dashboard(options: DashboardOptions = {}): Promise<void> {
       process.exit(0);
     });
   } else {
+    runtimeDb.close();
     logger.close();
   }
 }

--- a/src/cli/commands/monitor-impl.ts
+++ b/src/cli/commands/monitor-impl.ts
@@ -2,12 +2,13 @@ import { ethers } from "hardhat";
 import { ARBITRUM_MAINNET } from "../../config/addresses";
 import { DeltaNeutralMonitor } from "../../strategy/monitor";
 import { StrategyAction } from "../../strategy/types";
-import { loadStrategyConfig } from "../../config/strategy";
 import { getAmountsForLiquidity, getSqrtRatioAtTick } from "../../modules/math/ticks";
 import * as uniswapReader from "../../modules/uniswap/reader";
 import { getSignerAndAccount } from "./base";
 import { ERC20_ABI } from "../../utils/abis";
 import { sendErrorAlert, sendWarningAlert } from "../../utils/alerts";
+import { MonitoringDatabase } from "../../utils/database";
+import { loadEffectiveStrategyConfig } from "../../strategy/runtime-config";
 
 export interface MonitorOptions {
   account?: string;
@@ -18,6 +19,7 @@ export interface MonitorOptions {
 export async function monitor(options: MonitorOptions = {}): Promise<void> {
   const { account } = await getSignerAndAccount(options.account);
   console.log("Monitoring account:", account);
+  const runtimeDb = new MonitoringDatabase();
 
   // Configuration from environment or defaults
   const tokenIds = options.tokenId ? [BigInt(options.tokenId)] : undefined;
@@ -26,9 +28,11 @@ export async function monitor(options: MonitorOptions = {}): Promise<void> {
     ? ethers.parseUnits(options.minFeeThreshold, 30)
     : ethers.parseUnits("10", 30); // $10 worth of fees (USD 30 decimals)
 
-  const config = loadStrategyConfig({
+  const effectiveConfig = loadEffectiveStrategyConfig(runtimeDb, account).config;
+  const config = {
+    ...effectiveConfig,
     minOptimizationFeeThresholdUsd,
-  });
+  };
 
   const context = {
     uniswap: {
@@ -344,5 +348,7 @@ export async function monitor(options: MonitorOptions = {}): Promise<void> {
     });
 
     throw error;
+  } finally {
+    runtimeDb.close();
   }
 }

--- a/src/cli/commands/report-impl.ts
+++ b/src/cli/commands/report-impl.ts
@@ -1,7 +1,6 @@
 import { ethers } from "hardhat";
 import { ARBITRUM_MAINNET } from "../../config/addresses";
 import { DeltaNeutralMonitor } from "../../strategy/monitor";
-import { loadStrategyConfig } from "../../config/strategy";
 import { getAmountsForLiquidity, getSqrtRatioAtTick } from "../../modules/math/ticks";
 import * as uniswapReader from "../../modules/uniswap/reader";
 import { getSignerAndAccount } from "./base";
@@ -25,6 +24,7 @@ import {
   formatUsd30,
   projectCapitalBands,
 } from "../../utils/capital-bands";
+import { loadEffectiveStrategyConfig } from "../../strategy/runtime-config";
 
 export interface ReportOptions {
   account?: string;
@@ -42,7 +42,8 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
   logger.info("Generating daily report", { account, date: options.date });
 
   // Configuration
-  const config = loadStrategyConfig();
+  const db = new MonitoringDatabase();
+  const config = loadEffectiveStrategyConfig(db, account).config;
   const context = {
     uniswap: {
       positionManager: ARBITRUM_MAINNET.uniswapV3PositionManager,
@@ -172,7 +173,6 @@ export async function generateReport(options: ReportOptions = {}): Promise<void>
   };
 
   // Get APR metrics
-  const db = new MonitoringDatabase();
   let aprMetricsData: { apr1d?: number; apr7d?: number; apr30d?: number } = {};
   let netYield24h: bigint | undefined;
 

--- a/src/cli/commands/strategy.ts
+++ b/src/cli/commands/strategy.ts
@@ -3,6 +3,13 @@ import { addCommonOptions } from "./base";
 import { monitorPosition } from "./strategy/monitor-position";
 import { executeOptimize } from "./strategy/execute-optimize";
 import { closeAll } from "./strategy/close-all";
+import {
+  clearStrategyParam,
+  setAutoTuning,
+  setStrategyParam,
+  showStrategyParamHistory,
+  showStrategyParams,
+} from "./strategy/params";
 
 /**
  * Register all strategy commands
@@ -36,6 +43,7 @@ export function registerStrategyCommands(program: Command): void {
       .option("--price-lower <number>", "Lower price bound")
       .option("--price-upper <number>", "Upper price bound")
       .option("--slippage-bps <number>", "Slippage tolerance in basis points", "50")
+      .option("--db-path <path>", "SQLite DB path for runtime parameters")
       .option("--execute", "Actually execute the transaction (default: dry-run)", false)
       .action(async (options) => {
         await executeOptimize({
@@ -45,6 +53,7 @@ export function registerStrategyCommands(program: Command): void {
           priceLower: options.priceLower ? Number(options.priceLower) : undefined,
           priceUpper: options.priceUpper ? Number(options.priceUpper) : undefined,
           slippageBps: options.slippageBps ? BigInt(options.slippageBps) : undefined,
+          dbPath: options.dbPath,
           execute: options.execute ?? false,
         });
       })
@@ -62,6 +71,105 @@ export function registerStrategyCommands(program: Command): void {
           account: options.account,
           tokenId: options.tokenId,
           execute: options.execute ?? false,
+        });
+      })
+  );
+
+  const params = strategy.command("params").description("Manage runtime strategy parameters");
+
+  addCommonOptions(
+    params
+      .command("show")
+      .description("Show effective runtime strategy parameters")
+      .option("--global", "Show global scope parameters only", false)
+      .option("--db-path <path>", "SQLite DB path")
+      .action(async (options) => {
+        await showStrategyParams({
+          account: options.account,
+          global: options.global ?? false,
+          dbPath: options.dbPath,
+        });
+      })
+  );
+
+  addCommonOptions(
+    params
+      .command("set")
+      .description("Set a runtime strategy parameter")
+      .requiredOption("--key <key>", "Runtime strategy parameter key")
+      .requiredOption("--value <value>", "Numeric parameter value")
+      .option("--ttl <seconds>", "Optional TTL in seconds")
+      .option("--reason <text>", "Reason for the update")
+      .option("--global", "Write to global scope", false)
+      .option("--db-path <path>", "SQLite DB path")
+      .action(async (options) => {
+        await setStrategyParam({
+          account: options.account,
+          key: options.key,
+          value: options.value,
+          ttl: options.ttl !== undefined ? Number(options.ttl) : undefined,
+          reason: options.reason,
+          global: options.global ?? false,
+          dbPath: options.dbPath,
+        });
+      })
+  );
+
+  addCommonOptions(
+    params
+      .command("clear")
+      .description("Clear a runtime strategy parameter")
+      .requiredOption("--key <key>", "Runtime strategy parameter key")
+      .option("--reason <text>", "Reason for clearing the parameter")
+      .option("--global", "Clear from global scope", false)
+      .option("--db-path <path>", "SQLite DB path")
+      .action(async (options) => {
+        await clearStrategyParam({
+          account: options.account,
+          key: options.key,
+          reason: options.reason,
+          global: options.global ?? false,
+          dbPath: options.dbPath,
+        });
+      })
+  );
+
+  addCommonOptions(
+    params
+      .command("history")
+      .description("Show runtime strategy parameter history")
+      .option("--key <key>", "Filter by parameter key")
+      .option("--limit <n>", "Maximum history rows", "50")
+      .option("--global", "Show global scope history", false)
+      .option("--db-path <path>", "SQLite DB path")
+      .action(async (options) => {
+        await showStrategyParamHistory({
+          account: options.account,
+          key: options.key,
+          limit: options.limit ? Number(options.limit) : undefined,
+          global: options.global ?? false,
+          dbPath: options.dbPath,
+        });
+      })
+  );
+
+  addCommonOptions(
+    params
+      .command("auto")
+      .description("Enable or disable auto-tuning")
+      .option("--enable", "Enable auto-tuning", false)
+      .option("--disable", "Disable auto-tuning", false)
+      .option("--reason <text>", "Reason for this change")
+      .option("--global", "Update global scope", false)
+      .option("--db-path <path>", "SQLite DB path")
+      .action(async (options) => {
+        await setAutoTuning({
+          account: options.account,
+          enable: options.enable ?? false,
+          disable: options.disable ?? false,
+          reason: options.reason,
+          global: options.global ?? false,
+          dbPath: options.dbPath,
         });
       })
   );

--- a/src/cli/commands/strategy/execute-hedge-adjust.ts
+++ b/src/cli/commands/strategy/execute-hedge-adjust.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { ARBITRUM_MAINNET } from "../../../config/addresses";
-import { loadStrategyConfig } from "../../../config/strategy";
+import { StrategyConfig } from "../../../config/strategy";
 import * as gmxReader from "../../../modules/gmx/reader";
 import * as gmxOrders from "../../../modules/gmx/orders";
 import { getLatestPrice } from "../../../modules/chainlink/price";
@@ -11,6 +11,7 @@ import { ERC20_ABI } from "../../../utils/abis";
 import { sendSuccessAlert } from "../../../utils/alerts";
 import { GMXRouter, IERC20 } from "../../../modules/gmx/types";
 import { TransactionReceipt } from "ethers";
+import { loadEffectiveStrategyConfig } from "../../../strategy/runtime-config";
 
 export interface ExecuteHedgeAdjustOptions {
   account?: string;
@@ -19,6 +20,7 @@ export interface ExecuteHedgeAdjustOptions {
   execute?: boolean;
   suppressAlert?: boolean;
   dbPath?: string;
+  strategyConfig?: StrategyConfig;
 }
 
 export interface ExecuteHedgeAdjustResult {
@@ -38,7 +40,17 @@ export async function executeHedgeAdjust(
   options: ExecuteHedgeAdjustOptions
 ): Promise<ExecuteHedgeAdjustResult> {
   const { signer, account } = await getSignerAndAccount(options.account);
-  const config = loadStrategyConfig();
+  let config: StrategyConfig;
+  if (options.strategyConfig) {
+    config = options.strategyConfig;
+  } else {
+    const runtimeDb = new MonitoringDatabase(options.dbPath);
+    try {
+      config = loadEffectiveStrategyConfig(runtimeDb, account).config;
+    } finally {
+      runtimeDb.close();
+    }
+  }
   const { hedgeData, deltaDriftBefore } = options;
 
   const adjustmentSizeUsd = hedgeData.adjustmentSizeUsd;

--- a/src/cli/commands/strategy/execute-optimize.ts
+++ b/src/cli/commands/strategy/execute-optimize.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { Contract, Signer } from "ethers";
 import { ARBITRUM_MAINNET } from "../../../config/addresses";
 import { DeltaNeutralMonitor } from "../../../strategy/monitor";
-import { loadStrategyConfig, DEFAULT_STRATEGY_CONFIG, PRECISION } from "../../../config/strategy";
+import { loadStrategyConfig, PRECISION, StrategyConfig } from "../../../config/strategy";
 import { getDefaultRangeBounds } from "../../../config/markets";
 import { createPositionManager, getPosition } from "../../../modules/uniswap/reader";
 import {
@@ -45,6 +45,8 @@ import {
 
 import { toBigInt, refreshNonce } from "../../../utils/helpers";
 import { sendErrorAlert, sendSuccessAlert } from "../../../utils/alerts";
+import { loadEffectiveStrategyConfig } from "../../../strategy/runtime-config";
+import { resolveOptimizationRangeWidth } from "../../../strategy/optimize-defaults";
 
 export interface ExecuteOptimizeOptions {
   account?: string;
@@ -55,6 +57,8 @@ export interface ExecuteOptimizeOptions {
   slippageBps?: bigint;
   execute?: boolean;
   suppressAlert?: boolean;
+  strategyConfig?: StrategyConfig;
+  dbPath?: string;
 }
 
 /**
@@ -384,7 +388,20 @@ export async function executeOptimize(
     // 1. Check Strategy Status (for information, but don't gate execution)
     const tokenIds = options.tokenId ? [BigInt(options.tokenId)] : undefined;
 
+    let effectiveStrategyConfig: StrategyConfig;
+    if (options.strategyConfig) {
+      effectiveStrategyConfig = options.strategyConfig;
+    } else {
+      const runtimeDb = new MonitoringDatabase(options.dbPath);
+      try {
+        effectiveStrategyConfig = loadEffectiveStrategyConfig(runtimeDb, account).config;
+      } finally {
+        runtimeDb.close();
+      }
+    }
+
     const monitorConfig = loadStrategyConfig({
+      ...effectiveStrategyConfig,
       minOptimizationFeeThresholdUsd: ethers.parseUnits("10", 30),
     });
 
@@ -472,7 +489,7 @@ export async function executeOptimize(
     const priceUsdcPerWeth = isToken0Weth ? priceToken1PerToken0 : 1 / priceToken1PerToken0;
 
     // Calculate new range bounds using configured default (centered on current price)
-    const rangeWidth = options.rangeWidth ?? Number(DEFAULT_STRATEGY_CONFIG.defaultRangeWidth);
+    const rangeWidth = resolveOptimizationRangeWidth(options.rangeWidth, monitorConfig);
     const defaultBounds = getDefaultRangeBounds(priceUsdcPerWeth, rangeWidth);
     const lowerPrice = options.priceLower ?? Number(defaultBounds.lower.toFixed(6));
     const upperPrice = options.priceUpper ?? Number(defaultBounds.upper.toFixed(6));
@@ -652,7 +669,7 @@ export async function executeOptimize(
     // Note: We calculate tokens before closing (above) so we can plan the new position
     // The closePositions function handles the actual closing logic
     // Create database instance for recording fee collections (will be reused later for optimization recording)
-    const db = new MonitoringDatabase();
+    const db = new MonitoringDatabase(options.dbPath);
 
     // Track transaction receipts for gas cost calculation
     const transactionReceipts: Array<{ gasUsed: bigint; gasPrice: bigint }> = [];

--- a/src/cli/commands/strategy/monitor-position.ts
+++ b/src/cli/commands/strategy/monitor-position.ts
@@ -1,8 +1,9 @@
 import { ethers } from "hardhat";
 import { ARBITRUM_MAINNET } from "../../../config/addresses";
 import { DeltaNeutralMonitor } from "../../../strategy/monitor";
-import { loadStrategyConfig } from "../../../config/strategy";
 import { getSignerAndAccount } from "../base";
+import { MonitoringDatabase } from "../../../utils/database";
+import { loadEffectiveStrategyConfig } from "../../../strategy/runtime-config";
 
 export interface MonitorPositionOptions {
   account?: string;
@@ -11,37 +12,43 @@ export interface MonitorPositionOptions {
 
 export async function monitorPosition(options: MonitorPositionOptions = {}): Promise<void> {
   const { account } = await getSignerAndAccount(options.account);
+  const db = new MonitoringDatabase();
+  try {
+    const tokenIds = options.tokenId ? [BigInt(options.tokenId)] : undefined;
 
-  const tokenIds = options.tokenId ? [BigInt(options.tokenId)] : undefined;
+    const effectiveConfig = loadEffectiveStrategyConfig(db, account).config;
+    const config = {
+      ...effectiveConfig,
+      minOptimizationFeeThresholdUsd: ethers.parseUnits("10", 30),
+    };
 
-  const config = loadStrategyConfig({
-    minOptimizationFeeThresholdUsd: ethers.parseUnits("10", 30),
-  });
+    const context = {
+      uniswap: {
+        positionManager: ARBITRUM_MAINNET.uniswapV3PositionManager,
+        pool: ARBITRUM_MAINNET.uniswapV3EthUsdcPool,
+        tokenIds: tokenIds,
+      },
+      gmx: {
+        reader: ARBITRUM_MAINNET.gmxReader,
+        dataStore: ARBITRUM_MAINNET.gmxDataStore,
+        account: account,
+        market: ARBITRUM_MAINNET.gmxEthUsdMarket,
+        collateralToken: ARBITRUM_MAINNET.usdc,
+      },
+      multicall3: ARBITRUM_MAINNET.multicall3,
+    };
 
-  const context = {
-    uniswap: {
-      positionManager: ARBITRUM_MAINNET.uniswapV3PositionManager,
-      pool: ARBITRUM_MAINNET.uniswapV3EthUsdcPool,
-      tokenIds: tokenIds,
-    },
-    gmx: {
-      reader: ARBITRUM_MAINNET.gmxReader,
-      dataStore: ARBITRUM_MAINNET.gmxDataStore,
-      account: account,
-      market: ARBITRUM_MAINNET.gmxEthUsdMarket,
-      collateralToken: ARBITRUM_MAINNET.usdc,
-    },
-    multicall3: ARBITRUM_MAINNET.multicall3,
-  };
+    const monitor = new DeltaNeutralMonitor(ethers.provider, config, context);
 
-  const monitor = new DeltaNeutralMonitor(ethers.provider, config, context);
+    console.log("--- Strategy Check ---");
+    const { status, recommendation } = await monitor.check();
 
-  console.log("--- Strategy Check ---");
-  const { status, recommendation } = await monitor.check();
-
-  console.log("Status:", status);
-  console.log("Recommendation:", recommendation.action);
-  if (recommendation.reason) {
-    console.log("Reason:", recommendation.reason);
+    console.log("Status:", status);
+    console.log("Recommendation:", recommendation.action);
+    if (recommendation.reason) {
+      console.log("Reason:", recommendation.reason);
+    }
+  } finally {
+    db.close();
   }
 }

--- a/src/cli/commands/strategy/params.ts
+++ b/src/cli/commands/strategy/params.ts
@@ -1,0 +1,259 @@
+import { MonitoringDatabase, RuntimeParamRecord } from "../../../utils/database";
+import {
+  RUNTIME_STRATEGY_PARAM_KEYS,
+  RuntimeStrategyParamKey,
+  clearRuntimeStrategyParam,
+  getRuntimeControlValue,
+  isRuntimeStrategyParamKey,
+  loadEffectiveStrategyConfig,
+  parseRuntimeStrategyParamValue,
+  setRuntimeControlValue,
+  setRuntimeStrategyParam,
+} from "../../../strategy/runtime-config";
+import { getSignerAndAccount } from "../base";
+
+export interface StrategyParamsShowOptions {
+  account?: string;
+  global?: boolean;
+  dbPath?: string;
+}
+
+export interface StrategyParamsSetOptions {
+  account?: string;
+  key: string;
+  value: string;
+  ttl?: number;
+  reason?: string;
+  dbPath?: string;
+  global?: boolean;
+}
+
+export interface StrategyParamsClearOptions {
+  account?: string;
+  key: string;
+  reason?: string;
+  dbPath?: string;
+  global?: boolean;
+}
+
+export interface StrategyParamsHistoryOptions {
+  account?: string;
+  key?: string;
+  limit?: number;
+  dbPath?: string;
+  global?: boolean;
+}
+
+export interface StrategyParamsAutoOptions {
+  account?: string;
+  enable?: boolean;
+  disable?: boolean;
+  reason?: string;
+  dbPath?: string;
+  global?: boolean;
+}
+
+function formatScope(account: string | null): string {
+  return account === null ? "global" : `account:${account}`;
+}
+
+function formatParamRecord(record: RuntimeParamRecord): string {
+  const expires = record.expiresAt ? new Date(record.expiresAt).toISOString() : "none";
+  const lock = record.isLocked ? "locked" : "unlocked";
+  return `${record.key}=${record.value} (scope=${formatScope(record.account)}, source=${record.source}, ${lock}, expires=${expires}${record.reason ? `, reason=${record.reason}` : ""})`;
+}
+
+async function resolveScopeAccount(options: {
+  account?: string;
+  global?: boolean;
+}): Promise<string | null> {
+  if (options.global) {
+    return null;
+  }
+
+  const { account } = await getSignerAndAccount(options.account);
+  return account;
+}
+
+function assertRuntimeStrategyKey(key: string): RuntimeStrategyParamKey {
+  if (!isRuntimeStrategyParamKey(key)) {
+    throw new Error(
+      `Invalid runtime strategy key: ${key}. Allowed keys: ${RUNTIME_STRATEGY_PARAM_KEYS.join(", ")}`
+    );
+  }
+
+  return key;
+}
+
+function printEffectiveConfig(db: MonitoringDatabase, account: string | null): void {
+  const effective = loadEffectiveStrategyConfig(db, account ?? undefined).config;
+
+  console.log("Effective strategy config:");
+  for (const key of RUNTIME_STRATEGY_PARAM_KEYS) {
+    console.log(`  ${key}: ${effective[key]}`);
+  }
+}
+
+export async function showStrategyParams(options: StrategyParamsShowOptions): Promise<void> {
+  const scopeAccount = await resolveScopeAccount(options);
+  const db = new MonitoringDatabase(options.dbPath);
+
+  try {
+    const effective = loadEffectiveStrategyConfig(db, scopeAccount ?? undefined);
+    const activeParams = scopeAccount
+      ? db.listRuntimeParams({ account: scopeAccount, includeGlobal: true })
+      : db.listRuntimeParams({ account: null });
+
+    console.log(`Scope: ${formatScope(scopeAccount)}`);
+    console.log(`Applied runtime params: ${effective.appliedParams.length}`);
+
+    printEffectiveConfig(db, scopeAccount);
+
+    console.log("Active runtime parameters:");
+    if (activeParams.length === 0) {
+      console.log("  (none)");
+      return;
+    }
+
+    for (const param of activeParams) {
+      console.log(`  ${formatParamRecord(param)}`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+export async function setStrategyParam(options: StrategyParamsSetOptions): Promise<void> {
+  const scopeAccount = await resolveScopeAccount(options);
+  const key = assertRuntimeStrategyKey(options.key);
+  const value = parseRuntimeStrategyParamValue(key, options.value);
+
+  let expiresAt: number | undefined;
+  if (options.ttl !== undefined) {
+    if (!Number.isFinite(options.ttl) || options.ttl <= 0) {
+      throw new Error(`TTL must be a positive number of seconds, got ${options.ttl}`);
+    }
+    expiresAt = Date.now() + Math.floor(options.ttl * 1000);
+  }
+
+  const db = new MonitoringDatabase(options.dbPath);
+
+  try {
+    const result = setRuntimeStrategyParam({
+      db,
+      account: scopeAccount,
+      key,
+      value,
+      source: "manual",
+      expiresAt,
+      reason: options.reason,
+      isLocked: true,
+    });
+
+    if (!result.applied) {
+      throw new Error(`Failed to set ${key}: ${result.reason ?? "unknown"}`);
+    }
+
+    console.log(
+      `Set ${key}=${value} for ${formatScope(scopeAccount)}${expiresAt ? ` (expires ${new Date(expiresAt).toISOString()})` : ""}`
+    );
+    printEffectiveConfig(db, scopeAccount);
+  } finally {
+    db.close();
+  }
+}
+
+export async function clearStrategyParam(options: StrategyParamsClearOptions): Promise<void> {
+  const scopeAccount = await resolveScopeAccount(options);
+  const key = assertRuntimeStrategyKey(options.key);
+
+  const db = new MonitoringDatabase(options.dbPath);
+  try {
+    const result = clearRuntimeStrategyParam({
+      db,
+      account: scopeAccount,
+      key,
+      source: "manual",
+      reason: options.reason,
+    });
+
+    if (!result.cleared) {
+      console.log(`No runtime param found for ${key} on ${formatScope(scopeAccount)}.`);
+    } else {
+      console.log(`Cleared ${key} on ${formatScope(scopeAccount)}.`);
+    }
+
+    printEffectiveConfig(db, scopeAccount);
+  } finally {
+    db.close();
+  }
+}
+
+export async function showStrategyParamHistory(
+  options: StrategyParamsHistoryOptions
+): Promise<void> {
+  const scopeAccount = await resolveScopeAccount(options);
+  const db = new MonitoringDatabase(options.dbPath);
+
+  try {
+    const key = options.key ? assertRuntimeStrategyKey(options.key) : undefined;
+    const history = db.listRuntimeParamHistory({
+      account: scopeAccount,
+      key,
+      limit: options.limit,
+    });
+
+    console.log(`History scope: ${formatScope(scopeAccount)}`);
+    if (history.length === 0) {
+      console.log("No history entries.");
+      return;
+    }
+
+    for (const entry of history) {
+      const timestamp = new Date(entry.timestamp).toISOString();
+      console.log(
+        `${timestamp} ${entry.action.toUpperCase()} ${entry.key} scope=${formatScope(entry.account)} source=${entry.source} old=${entry.oldValue ?? "null"} new=${entry.newValue ?? "null"}${entry.reason ? ` reason=${entry.reason}` : ""}`
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+export async function setAutoTuning(options: StrategyParamsAutoOptions): Promise<void> {
+  if ((options.enable && options.disable) || (!options.enable && !options.disable)) {
+    throw new Error("Provide exactly one of --enable or --disable");
+  }
+
+  const enabled = Boolean(options.enable);
+  const scopeAccount = await resolveScopeAccount(options);
+  const db = new MonitoringDatabase(options.dbPath);
+
+  try {
+    const result = setRuntimeControlValue({
+      db,
+      account: scopeAccount,
+      key: "autoTuningEnabled",
+      value: enabled,
+      source: "manual",
+      reason: options.reason ?? (enabled ? "auto-tuner enabled" : "auto-tuner disabled"),
+      isLocked: true,
+    });
+
+    if (!result.applied) {
+      throw new Error(`Failed to update auto-tuner state: ${result.reason ?? "unknown"}`);
+    }
+
+    const effectiveValue = getRuntimeControlValue<boolean>(
+      db,
+      "autoTuningEnabled",
+      scopeAccount ?? undefined
+    );
+
+    console.log(
+      `Auto-tuner ${enabled ? "enabled" : "disabled"} for ${formatScope(scopeAccount)}. Effective value: ${effectiveValue}`
+    );
+  } finally {
+    db.close();
+  }
+}

--- a/src/config/strategy.ts
+++ b/src/config/strategy.ts
@@ -119,8 +119,8 @@ export const DEFAULT_STRATEGY_CONFIG: StrategyConfig = {
   estimatedOptimizationGasCostUsd: BigInt(2) * PRECISION.GMX_USD, // ~$2 in gas costs (30 decimals)
 
   // Range adjustment parameters
-  rangeAdjustmentThreshold: 0.02, // 2%
-  rangeCenterDriftThreshold: 0.05, // 5%
+  rangeAdjustmentThreshold: 0.15, // Trigger when price is within 15% of range span from either edge
+  rangeCenterDriftThreshold: 0.02, // Trigger when price drifts 2% from center (proactive for 6% width)
 
   // Range size parameters
   defaultRangeWidth: 0.06, // 6% total width (±3% on each side) - tighter range for higher capital efficiency
@@ -289,6 +289,11 @@ export function validateStrategyConfig(config: StrategyConfig): void {
       `rangeAdjustmentThreshold must be between 0 and 1, got ${config.rangeAdjustmentThreshold}`
     );
   }
+  if (config.rangeAdjustmentThreshold >= 0.5) {
+    throw new Error(
+      `rangeAdjustmentThreshold (${config.rangeAdjustmentThreshold}) must be less than 0.5 (distance-to-edge ratio)`
+    );
+  }
   if (config.rangeCenterDriftThreshold <= 0 || config.rangeCenterDriftThreshold >= 1) {
     throw new Error(
       `rangeCenterDriftThreshold must be between 0 and 1, got ${config.rangeCenterDriftThreshold}`
@@ -305,6 +310,14 @@ export function validateStrategyConfig(config: StrategyConfig): void {
   if (config.maxRangeWidth <= config.defaultRangeWidth) {
     throw new Error(
       `maxRangeWidth (${config.maxRangeWidth}) must be greater than defaultRangeWidth (${config.defaultRangeWidth})`
+    );
+  }
+  if (config.maxRangeWidth >= 1) {
+    throw new Error(`maxRangeWidth must be less than 1, got ${config.maxRangeWidth}`);
+  }
+  if (config.rangeCenterDriftThreshold >= config.defaultRangeWidth / 2) {
+    throw new Error(
+      `rangeCenterDriftThreshold (${config.rangeCenterDriftThreshold}) must be less than half of defaultRangeWidth (${config.defaultRangeWidth / 2})`
     );
   }
 

--- a/src/strategy/auto-tuner.ts
+++ b/src/strategy/auto-tuner.ts
@@ -1,0 +1,455 @@
+import { StrategyConfig } from "../config/strategy";
+import { MonitoringDatabase } from "../utils/database";
+import {
+  RuntimeStrategyParamKey,
+  getRuntimeControlValue,
+  setRuntimeControlValue,
+} from "./runtime-config";
+
+export type MarketRegime = "calm" | "normal" | "volatile" | "extreme";
+
+export interface AutoTunerMetrics {
+  volatility1h: number;
+  volatility24h: number;
+  outOfRangeFrequency24h: number;
+  hedgeAdjustmentsPerHour: number;
+  optimizationsPerHour: number;
+  feeToCostRatio24h: number;
+}
+
+export interface AutoTunerState {
+  activeRegime: MarketRegime;
+  pendingRegime: MarketRegime | null;
+  pendingCount: number;
+  updatedAt: number;
+}
+
+export interface AutoTuneChange {
+  key: RuntimeStrategyParamKey;
+  previous: number;
+  next: number;
+  skipped: boolean;
+  reason?: string;
+}
+
+export interface AutoTuneResult {
+  enabled: boolean;
+  applied: boolean;
+  regime: MarketRegime;
+  candidateRegime: MarketRegime;
+  metrics: AutoTunerMetrics;
+  changes: AutoTuneChange[];
+}
+
+const HYSTERESIS_CYCLES = 2;
+
+const REGIME_TARGETS: Record<
+  MarketRegime,
+  Pick<
+    StrategyConfig,
+    | "defaultRangeWidth"
+    | "rangeAdjustmentThreshold"
+    | "rangeCenterDriftThreshold"
+    | "hedgeDeltaThreshold"
+    | "optimizationDeltaThreshold"
+    | "emergencyDeltaThreshold"
+  >
+> = {
+  calm: {
+    defaultRangeWidth: 0.05,
+    rangeAdjustmentThreshold: 0.12,
+    rangeCenterDriftThreshold: 0.015,
+    hedgeDeltaThreshold: 0.06,
+    optimizationDeltaThreshold: 0.12,
+    emergencyDeltaThreshold: 0.22,
+  },
+  normal: {
+    defaultRangeWidth: 0.06,
+    rangeAdjustmentThreshold: 0.15,
+    rangeCenterDriftThreshold: 0.02,
+    hedgeDeltaThreshold: 0.05,
+    optimizationDeltaThreshold: 0.1,
+    emergencyDeltaThreshold: 0.2,
+  },
+  volatile: {
+    defaultRangeWidth: 0.1,
+    rangeAdjustmentThreshold: 0.2,
+    rangeCenterDriftThreshold: 0.03,
+    hedgeDeltaThreshold: 0.04,
+    optimizationDeltaThreshold: 0.08,
+    emergencyDeltaThreshold: 0.15,
+  },
+  extreme: {
+    defaultRangeWidth: 0.14,
+    rangeAdjustmentThreshold: 0.25,
+    rangeCenterDriftThreshold: 0.04,
+    hedgeDeltaThreshold: 0.03,
+    optimizationDeltaThreshold: 0.06,
+    emergencyDeltaThreshold: 0.12,
+  },
+};
+
+const STEP_CAPS: Record<RuntimeStrategyParamKey, number> = {
+  defaultRangeWidth: 0.02,
+  rangeAdjustmentThreshold: 0.05,
+  rangeCenterDriftThreshold: 0.01,
+  hedgeDeltaThreshold: 0.02,
+  optimizationDeltaThreshold: 0.02,
+  emergencyDeltaThreshold: 0.03,
+  minRangeWidth: 0.02,
+  maxRangeWidth: 0.05,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function standardDeviation(values: number[]): number {
+  if (values.length < 2) {
+    return 0;
+  }
+
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance =
+    values.reduce((sum, value) => sum + (value - mean) * (value - mean), 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+function computeRealizedVolatility(prices: number[]): number {
+  if (prices.length < 2) {
+    return 0;
+  }
+
+  const returns: number[] = [];
+  for (let i = 1; i < prices.length; i++) {
+    const prev = prices[i - 1];
+    const next = prices[i];
+    if (prev <= 0 || next <= 0) {
+      continue;
+    }
+    returns.push(Math.log(next / prev));
+  }
+
+  return standardDeviation(returns);
+}
+
+function getPriceSeries(db: MonitoringDatabase, account: string, sinceMs: number): number[] {
+  const rows = db
+    .getDb()
+    .prepare(
+      `
+      SELECT ms.timestamp, AVG(ps.current_price) AS current_price
+      FROM monitoring_snapshots ms
+      JOIN position_snapshots ps ON ps.snapshot_id = ms.id
+      WHERE ms.account = ?
+        AND ms.timestamp >= ?
+        AND ps.position_type = 'uniswap'
+      GROUP BY ms.id
+      ORDER BY ms.timestamp ASC
+    `
+    )
+    .all(account, sinceMs) as Array<{ timestamp: number; current_price: number }>;
+
+  return rows
+    .map((row) => row.current_price)
+    .filter((price) => Number.isFinite(price) && price > 0);
+}
+
+function countOptimizations(db: MonitoringDatabase, account: string, sinceMs: number): number {
+  const row = db
+    .getDb()
+    .prepare(
+      `
+      SELECT COUNT(*) AS count
+      FROM optimization_history
+      WHERE account = ? AND timestamp >= ?
+    `
+    )
+    .get(account, sinceMs) as { count: number };
+
+  return row.count;
+}
+
+function determineRegime(metrics: AutoTunerMetrics): MarketRegime {
+  if (
+    metrics.volatility1h >= 0.08 ||
+    metrics.volatility24h >= 0.09 ||
+    metrics.outOfRangeFrequency24h >= 0.2 ||
+    metrics.optimizationsPerHour >= 2.0
+  ) {
+    return "extreme";
+  }
+
+  if (
+    metrics.volatility1h >= 0.04 ||
+    metrics.volatility24h >= 0.05 ||
+    metrics.outOfRangeFrequency24h >= 0.1 ||
+    metrics.hedgeAdjustmentsPerHour >= 2.5
+  ) {
+    return "volatile";
+  }
+
+  if (
+    metrics.volatility1h <= 0.012 &&
+    metrics.volatility24h <= 0.015 &&
+    metrics.outOfRangeFrequency24h <= 0.03 &&
+    metrics.hedgeAdjustmentsPerHour <= 0.5 &&
+    metrics.feeToCostRatio24h >= 1.5
+  ) {
+    return "calm";
+  }
+
+  return "normal";
+}
+
+function loadAutoTunerState(db: MonitoringDatabase, account: string): AutoTunerState {
+  const saved = getRuntimeControlValue<AutoTunerState>(db, "autoTunerState", account);
+
+  if (!saved) {
+    return {
+      activeRegime: "normal",
+      pendingRegime: null,
+      pendingCount: 0,
+      updatedAt: Date.now(),
+    };
+  }
+
+  return {
+    activeRegime: saved.activeRegime,
+    pendingRegime: saved.pendingRegime,
+    pendingCount: saved.pendingCount,
+    updatedAt: saved.updatedAt,
+  };
+}
+
+function persistAutoTunerState(
+  db: MonitoringDatabase,
+  account: string,
+  state: AutoTunerState
+): void {
+  setRuntimeControlValue({
+    db,
+    account,
+    key: "autoTunerState",
+    value: state as unknown as Record<string, unknown>,
+    source: "auto",
+    reason: `Auto-tuner state update (${state.activeRegime})`,
+    isLocked: false,
+  });
+}
+
+function calculateTargetValue(
+  key: RuntimeStrategyParamKey,
+  config: StrategyConfig,
+  regime: MarketRegime
+): number {
+  switch (key) {
+    case "defaultRangeWidth":
+      return clamp(
+        REGIME_TARGETS[regime].defaultRangeWidth,
+        config.minRangeWidth + 1e-6,
+        config.maxRangeWidth - 1e-6
+      );
+    case "rangeAdjustmentThreshold":
+      return REGIME_TARGETS[regime].rangeAdjustmentThreshold;
+    case "rangeCenterDriftThreshold": {
+      const target = REGIME_TARGETS[regime].rangeCenterDriftThreshold;
+      return Math.min(target, config.defaultRangeWidth / 2 - 1e-6);
+    }
+    case "hedgeDeltaThreshold":
+      return REGIME_TARGETS[regime].hedgeDeltaThreshold;
+    case "optimizationDeltaThreshold":
+      return REGIME_TARGETS[regime].optimizationDeltaThreshold;
+    case "emergencyDeltaThreshold":
+      return REGIME_TARGETS[regime].emergencyDeltaThreshold;
+    case "minRangeWidth":
+      return config.minRangeWidth;
+    case "maxRangeWidth":
+      return config.maxRangeWidth;
+  }
+}
+
+function applyStepCap(current: number, target: number, cap: number): number {
+  if (Math.abs(target - current) <= cap) {
+    return target;
+  }
+
+  return target > current ? current + cap : current - cap;
+}
+
+export function calculateAutoTunerMetrics(
+  db: MonitoringDatabase,
+  account: string,
+  now: number = Date.now()
+): AutoTunerMetrics {
+  const oneHourAgo = now - 60 * 60 * 1000;
+  const oneDayAgo = now - 24 * 60 * 60 * 1000;
+
+  const prices1h = getPriceSeries(db, account, oneHourAgo);
+  const prices24h = getPriceSeries(db, account, oneDayAgo);
+  const snapshots24h = db.getSnapshots(account, oneDayAgo, now);
+
+  const outOfRangeCount = snapshots24h.filter((snapshot) =>
+    snapshot.recommendationReason.toLowerCase().includes("out of range")
+  ).length;
+
+  const hedgeAdjustments1h = db
+    .getRecentHedgeAdjustments(account, 200)
+    .filter((entry) => entry.timestamp >= oneHourAgo).length;
+
+  const optimizations1h = countOptimizations(db, account, oneHourAgo);
+
+  const fees24h = db.getFeesCollected(account, oneDayAgo, now);
+  const costs24h = db.getTotalCosts(account, oneDayAgo, now);
+
+  let feeToCostRatio24h = 0;
+  if (costs24h > 0n) {
+    feeToCostRatio24h = Number(fees24h) / Number(costs24h);
+  } else if (fees24h > 0n) {
+    feeToCostRatio24h = Number.POSITIVE_INFINITY;
+  }
+
+  return {
+    volatility1h: computeRealizedVolatility(prices1h),
+    volatility24h: computeRealizedVolatility(prices24h),
+    outOfRangeFrequency24h: snapshots24h.length > 0 ? outOfRangeCount / snapshots24h.length : 0,
+    hedgeAdjustmentsPerHour: hedgeAdjustments1h,
+    optimizationsPerHour: optimizations1h,
+    feeToCostRatio24h,
+  };
+}
+
+export function runAutoTuner(params: {
+  db: MonitoringDatabase;
+  account: string;
+  effectiveConfig: StrategyConfig;
+  now?: number;
+}): AutoTuneResult {
+  const { db, account, effectiveConfig } = params;
+  const now = params.now ?? Date.now();
+  const enabled = getRuntimeControlValue<boolean>(db, "autoTuningEnabled", account) ?? false;
+  const metrics = calculateAutoTunerMetrics(db, account, now);
+  const candidateRegime = determineRegime(metrics);
+
+  if (!enabled) {
+    return {
+      enabled: false,
+      applied: false,
+      regime: "normal",
+      candidateRegime,
+      metrics,
+      changes: [],
+    };
+  }
+
+  const state = loadAutoTunerState(db, account);
+
+  if (candidateRegime === state.activeRegime) {
+    state.pendingRegime = null;
+    state.pendingCount = 0;
+    state.updatedAt = now;
+    persistAutoTunerState(db, account, state);
+
+    return {
+      enabled: true,
+      applied: false,
+      regime: state.activeRegime,
+      candidateRegime,
+      metrics,
+      changes: [],
+    };
+  }
+
+  if (state.pendingRegime === candidateRegime) {
+    state.pendingCount += 1;
+  } else {
+    state.pendingRegime = candidateRegime;
+    state.pendingCount = 1;
+  }
+
+  if (state.pendingCount < HYSTERESIS_CYCLES) {
+    state.updatedAt = now;
+    persistAutoTunerState(db, account, state);
+
+    return {
+      enabled: true,
+      applied: false,
+      regime: state.activeRegime,
+      candidateRegime,
+      metrics,
+      changes: [],
+    };
+  }
+
+  const keysToTune: RuntimeStrategyParamKey[] = [
+    "defaultRangeWidth",
+    "rangeAdjustmentThreshold",
+    "rangeCenterDriftThreshold",
+    "hedgeDeltaThreshold",
+    "optimizationDeltaThreshold",
+    "emergencyDeltaThreshold",
+  ];
+
+  const changes: AutoTuneChange[] = [];
+  for (const key of keysToTune) {
+    const target = calculateTargetValue(key, effectiveConfig, candidateRegime);
+    const current = effectiveConfig[key] as number;
+    const stepped = applyStepCap(current, target, STEP_CAPS[key]);
+
+    const globalParam = db.getRuntimeParam(null, key);
+    const accountParam = db.getRuntimeParam(account, key);
+    const hasManualLock =
+      (globalParam?.source === "manual" && globalParam.isLocked) ||
+      (accountParam?.source === "manual" && accountParam.isLocked);
+
+    if (hasManualLock) {
+      changes.push({
+        key,
+        previous: current,
+        next: current,
+        skipped: true,
+        reason: "manual-lock",
+      });
+      continue;
+    }
+
+    const update = db.setRuntimeParam(account, key, stepped, {
+      source: "auto",
+      reason: `Auto-tuner ${state.activeRegime} -> ${candidateRegime}`,
+      isLocked: false,
+    });
+
+    if (!update.applied) {
+      changes.push({
+        key,
+        previous: current,
+        next: current,
+        skipped: true,
+        reason: update.reason,
+      });
+      continue;
+    }
+
+    changes.push({
+      key,
+      previous: current,
+      next: stepped,
+      skipped: false,
+    });
+  }
+
+  state.activeRegime = candidateRegime;
+  state.pendingRegime = null;
+  state.pendingCount = 0;
+  state.updatedAt = now;
+  persistAutoTunerState(db, account, state);
+
+  return {
+    enabled: true,
+    applied: changes.some((change) => !change.skipped),
+    regime: state.activeRegime,
+    candidateRegime,
+    metrics,
+    changes,
+  };
+}

--- a/src/strategy/monitor.ts
+++ b/src/strategy/monitor.ts
@@ -60,6 +60,14 @@ export class DeltaNeutralMonitor implements StrategyMonitor {
     private database?: MonitoringDatabase
   ) {}
 
+  setConfig(config: StrategyConfig): void {
+    this.config = config;
+  }
+
+  getConfig(): StrategyConfig {
+    return this.config;
+  }
+
   async check(): Promise<{ status: StrategyStatus; recommendation: Recommendation }> {
     const { uniswap, gmx } = this.context;
 

--- a/src/strategy/optimize-defaults.ts
+++ b/src/strategy/optimize-defaults.ts
@@ -1,0 +1,8 @@
+import { StrategyConfig } from "../config/strategy";
+
+export function resolveOptimizationRangeWidth(
+  rangeWidthOverride: number | undefined,
+  config: StrategyConfig
+): number {
+  return rangeWidthOverride ?? Number(config.defaultRangeWidth);
+}

--- a/src/strategy/runtime-config.ts
+++ b/src/strategy/runtime-config.ts
@@ -1,0 +1,225 @@
+import * as strategyConfigModule from "../config/strategy";
+import { StrategyConfig } from "../config/strategy";
+import { MonitoringDatabase, RuntimeParamRecord, RuntimeParamSource } from "../utils/database";
+
+export const RUNTIME_STRATEGY_PARAM_KEYS = [
+  "defaultRangeWidth",
+  "rangeAdjustmentThreshold",
+  "rangeCenterDriftThreshold",
+  "hedgeDeltaThreshold",
+  "optimizationDeltaThreshold",
+  "emergencyDeltaThreshold",
+  "minRangeWidth",
+  "maxRangeWidth",
+] as const;
+
+export type RuntimeStrategyParamKey = (typeof RUNTIME_STRATEGY_PARAM_KEYS)[number];
+
+export const RUNTIME_CONTROL_KEYS = ["autoTuningEnabled", "autoTunerState"] as const;
+export type RuntimeControlKey = (typeof RUNTIME_CONTROL_KEYS)[number];
+
+const RUNTIME_STRATEGY_PARAM_KEY_SET = new Set<string>(RUNTIME_STRATEGY_PARAM_KEYS);
+
+export interface EffectiveStrategyConfig {
+  config: StrategyConfig;
+  appliedParams: RuntimeParamRecord[];
+  globalParams: RuntimeParamRecord[];
+  accountParams: RuntimeParamRecord[];
+}
+
+export interface StrategyConfigDiff {
+  key: keyof StrategyConfig;
+  before: string;
+  after: string;
+}
+
+function validateEffectiveConfig(config: StrategyConfig): void {
+  const validator = strategyConfigModule.validateStrategyConfig as unknown as
+    | ((nextConfig: StrategyConfig) => void)
+    | undefined;
+
+  if (typeof validator === "function") {
+    validator(config);
+  }
+}
+
+export function isRuntimeStrategyParamKey(key: string): key is RuntimeStrategyParamKey {
+  return RUNTIME_STRATEGY_PARAM_KEY_SET.has(key);
+}
+
+function applyRuntimeParams(config: StrategyConfig, params: RuntimeParamRecord[]): StrategyConfig {
+  const nextConfig = { ...config };
+
+  for (const param of params) {
+    if (!isRuntimeStrategyParamKey(param.key)) {
+      continue;
+    }
+
+    (nextConfig as Record<string, unknown>)[param.key] = param.value;
+  }
+
+  return nextConfig;
+}
+
+export function loadEffectiveStrategyConfig(
+  db: MonitoringDatabase,
+  account?: string,
+  overrides?: Partial<StrategyConfig>
+): EffectiveStrategyConfig {
+  const base = strategyConfigModule.loadStrategyConfig();
+  const runtimeSnapshotLoader = (
+    db as unknown as {
+      getRuntimeParamSnapshot?: (scopeAccount?: string) => {
+        globalParams: RuntimeParamRecord[];
+        accountParams: RuntimeParamRecord[];
+      };
+    }
+  ).getRuntimeParamSnapshot;
+
+  const { globalParams, accountParams } =
+    typeof runtimeSnapshotLoader === "function"
+      ? runtimeSnapshotLoader.call(db, account)
+      : { globalParams: [], accountParams: [] };
+
+  const globalStrategyParams = globalParams.filter((param) => isRuntimeStrategyParamKey(param.key));
+  const accountStrategyParams = accountParams.filter((param) =>
+    isRuntimeStrategyParamKey(param.key)
+  );
+
+  let config = applyRuntimeParams(base, globalStrategyParams);
+  config = applyRuntimeParams(config, accountStrategyParams);
+
+  if (overrides) {
+    Object.assign(config, overrides);
+  }
+
+  validateEffectiveConfig(config);
+
+  return {
+    config,
+    appliedParams: [...globalStrategyParams, ...accountStrategyParams],
+    globalParams,
+    accountParams,
+  };
+}
+
+export function setRuntimeStrategyParam(params: {
+  db: MonitoringDatabase;
+  account?: string | null;
+  key: RuntimeStrategyParamKey;
+  value: number;
+  source?: RuntimeParamSource;
+  expiresAt?: number;
+  reason?: string;
+  isLocked?: boolean;
+}): { applied: boolean; reason?: string; effectiveConfig: StrategyConfig } {
+  const { db, account = null, key, value, source, expiresAt, reason, isLocked } = params;
+
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid value for ${key}: ${value}`);
+  }
+
+  const effectiveBefore = loadEffectiveStrategyConfig(db, account ?? undefined).config;
+  const candidate = { ...effectiveBefore, [key]: value } as StrategyConfig;
+  validateEffectiveConfig(candidate);
+
+  const result = db.setRuntimeParam(account, key, value, {
+    source,
+    expiresAt,
+    reason,
+    isLocked,
+  });
+
+  const effectiveConfig = loadEffectiveStrategyConfig(db, account ?? undefined).config;
+  return { ...result, effectiveConfig };
+}
+
+export function clearRuntimeStrategyParam(params: {
+  db: MonitoringDatabase;
+  account?: string | null;
+  key: RuntimeStrategyParamKey;
+  source?: RuntimeParamSource;
+  reason?: string;
+}): { cleared: boolean; effectiveConfig: StrategyConfig } {
+  const { db, account = null, key, source, reason } = params;
+
+  const cleared = db.clearRuntimeParam(account, key, {
+    source,
+    reason,
+  });
+
+  const effectiveConfig = loadEffectiveStrategyConfig(db, account ?? undefined).config;
+  return { cleared, effectiveConfig };
+}
+
+export function getRuntimeControlValue<T>(
+  db: MonitoringDatabase,
+  key: RuntimeControlKey,
+  account?: string
+): T | undefined {
+  const { globalParams, accountParams } = db.getRuntimeParamSnapshot(account);
+
+  const accountValue = accountParams.find((param) => param.key === key);
+  if (accountValue) {
+    return accountValue.value as T;
+  }
+
+  const globalValue = globalParams.find((param) => param.key === key);
+  if (globalValue) {
+    return globalValue.value as T;
+  }
+
+  return undefined;
+}
+
+export function setRuntimeControlValue(params: {
+  db: MonitoringDatabase;
+  account?: string | null;
+  key: RuntimeControlKey;
+  value: boolean | Record<string, unknown>;
+  source?: RuntimeParamSource;
+  expiresAt?: number;
+  reason?: string;
+  isLocked?: boolean;
+}): { applied: boolean; reason?: string } {
+  const { db, account = null, key, value, source, expiresAt, reason, isLocked = true } = params;
+
+  return db.setRuntimeParam(account, key, value, {
+    source,
+    expiresAt,
+    reason,
+    isLocked,
+  });
+}
+
+export function diffStrategyConfigs(
+  previous: StrategyConfig,
+  next: StrategyConfig
+): StrategyConfigDiff[] {
+  const keys = Object.keys(
+    strategyConfigModule.DEFAULT_STRATEGY_CONFIG
+  ) as (keyof StrategyConfig)[];
+  const changes: StrategyConfigDiff[] = [];
+
+  for (const key of keys) {
+    if (previous[key] === next[key]) {
+      continue;
+    }
+
+    changes.push({
+      key,
+      before: String(previous[key]),
+      after: String(next[key]),
+    });
+  }
+
+  return changes;
+}
+
+export function parseRuntimeStrategyParamValue(key: RuntimeStrategyParamKey, raw: string): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid numeric value for ${key}: ${raw}`);
+  }
+  return value;
+}

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -47,6 +47,34 @@ export interface NavHistory {
   navUsd: string;
 }
 
+export type RuntimeParamSource = "manual" | "auto";
+
+export interface RuntimeParamRecord {
+  id: number;
+  account: string | null;
+  key: string;
+  value: any;
+  source: RuntimeParamSource;
+  isLocked: boolean;
+  updatedAt: number;
+  expiresAt: number | null;
+  reason: string | null;
+}
+
+export interface RuntimeParamHistoryRecord {
+  id: number;
+  timestamp: number;
+  account: string | null;
+  key: string;
+  oldValue: any | null;
+  newValue: any | null;
+  source: RuntimeParamSource;
+  action: "set" | "clear" | "expire";
+  isLocked: boolean | null;
+  expiresAt: number | null;
+  reason: string | null;
+}
+
 /**
  * Database service for storing monitoring data
  */
@@ -779,6 +807,320 @@ export class MonitoringDatabase {
   }
 
   /**
+   * Set a runtime strategy parameter override.
+   * Auto updates will not overwrite manually locked parameters.
+   */
+  setRuntimeParam(
+    account: string | null,
+    key: string,
+    value: any,
+    options: {
+      source?: RuntimeParamSource;
+      expiresAt?: number;
+      reason?: string;
+      isLocked?: boolean;
+    } = {}
+  ): { applied: boolean; reason?: string } {
+    this.cleanupExpiredRuntimeParams(account);
+
+    const source = options.source ?? "manual";
+    const isLocked = options.isLocked ?? source === "manual";
+    const now = Date.now();
+    const newValue = JSON.stringify(value);
+
+    const currentStmt = this.db.prepare(`
+      SELECT id, param_value, source, is_locked, expires_at
+      FROM runtime_params
+      WHERE account IS ? AND param_key = ?
+    `);
+
+    const existing = currentStmt.get(account, key) as
+      | {
+          id: number;
+          param_value: string;
+          source: RuntimeParamSource;
+          is_locked: number;
+          expires_at: number | null;
+        }
+      | undefined;
+
+    if (
+      source === "auto" &&
+      existing &&
+      (existing.source === "manual" || existing.is_locked === 1)
+    ) {
+      return { applied: false, reason: "manual-lock" };
+    }
+
+    const upsert = this.db.prepare(`
+      INSERT INTO runtime_params (
+        account, param_key, param_value, source, is_locked, updated_at, expires_at, reason
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(account, param_key) DO UPDATE SET
+        param_value = excluded.param_value,
+        source = excluded.source,
+        is_locked = excluded.is_locked,
+        updated_at = excluded.updated_at,
+        expires_at = excluded.expires_at,
+        reason = excluded.reason
+    `);
+
+    upsert.run(
+      account,
+      key,
+      newValue,
+      source,
+      isLocked ? 1 : 0,
+      now,
+      options.expiresAt ?? null,
+      options.reason ?? null
+    );
+
+    this.recordRuntimeParamHistory({
+      account,
+      key,
+      oldValue: existing?.param_value ?? null,
+      newValue,
+      source,
+      action: "set",
+      isLocked: isLocked ? 1 : 0,
+      expiresAt: options.expiresAt ?? null,
+      reason: options.reason ?? null,
+    });
+
+    return { applied: true };
+  }
+
+  /**
+   * Get a single runtime parameter override.
+   */
+  getRuntimeParam(account: string | null, key: string): RuntimeParamRecord | null {
+    this.cleanupExpiredRuntimeParams(account);
+
+    const stmt = this.db.prepare(`
+      SELECT id, account, param_key, param_value, source, is_locked, updated_at, expires_at, reason
+      FROM runtime_params
+      WHERE account IS ? AND param_key = ?
+    `);
+
+    const row = stmt.get(account, key) as
+      | {
+          id: number;
+          account: string | null;
+          param_key: string;
+          param_value: string;
+          source: RuntimeParamSource;
+          is_locked: number;
+          updated_at: number;
+          expires_at: number | null;
+          reason: string | null;
+        }
+      | undefined;
+
+    if (!row) {
+      return null;
+    }
+
+    return this.mapRuntimeParamRow(row);
+  }
+
+  /**
+   * List active runtime parameters.
+   */
+  listRuntimeParams(
+    options: {
+      account?: string | null;
+      includeGlobal?: boolean;
+      key?: string;
+    } = {}
+  ): RuntimeParamRecord[] {
+    const { account, includeGlobal = false, key } = options;
+    this.cleanupExpiredRuntimeParams(account);
+
+    let query = `
+      SELECT id, account, param_key, param_value, source, is_locked, updated_at, expires_at, reason
+      FROM runtime_params
+      WHERE 1 = 1
+    `;
+    const params: any[] = [];
+
+    if (account === undefined) {
+      if (!includeGlobal) {
+        query += " AND account IS NULL";
+      }
+    } else if (includeGlobal && account !== null) {
+      query += " AND (account IS NULL OR account = ?)";
+      params.push(account);
+    } else if (account === null) {
+      query += " AND account IS NULL";
+    } else {
+      query += " AND account = ?";
+      params.push(account);
+    }
+
+    if (key) {
+      query += " AND param_key = ?";
+      params.push(key);
+    }
+
+    query += " ORDER BY CASE WHEN account IS NULL THEN 0 ELSE 1 END, updated_at DESC, id DESC";
+
+    const rows = this.db.prepare(query).all(...params) as Array<{
+      id: number;
+      account: string | null;
+      param_key: string;
+      param_value: string;
+      source: RuntimeParamSource;
+      is_locked: number;
+      updated_at: number;
+      expires_at: number | null;
+      reason: string | null;
+    }>;
+
+    return rows.map((row) => this.mapRuntimeParamRow(row));
+  }
+
+  /**
+   * Fetch global and account runtime parameters in one query.
+   */
+  getRuntimeParamSnapshot(account?: string): {
+    globalParams: RuntimeParamRecord[];
+    accountParams: RuntimeParamRecord[];
+  } {
+    if (!account) {
+      return {
+        globalParams: this.listRuntimeParams({ account: null }),
+        accountParams: [],
+      };
+    }
+
+    const allParams = this.listRuntimeParams({
+      account,
+      includeGlobal: true,
+    });
+
+    return {
+      globalParams: allParams.filter((param) => param.account === null),
+      accountParams: allParams.filter((param) => param.account === account),
+    };
+  }
+
+  /**
+   * Clear a runtime parameter override.
+   */
+  clearRuntimeParam(
+    account: string | null,
+    key: string,
+    options: { source?: RuntimeParamSource; reason?: string } = {}
+  ): boolean {
+    this.cleanupExpiredRuntimeParams(account);
+
+    const source = options.source ?? "manual";
+
+    const existingStmt = this.db.prepare(`
+      SELECT id, param_value, is_locked, expires_at, reason
+      FROM runtime_params
+      WHERE account IS ? AND param_key = ?
+    `);
+
+    const existing = existingStmt.get(account, key) as
+      | {
+          id: number;
+          param_value: string;
+          is_locked: number;
+          expires_at: number | null;
+          reason: string | null;
+        }
+      | undefined;
+
+    if (!existing) {
+      return false;
+    }
+
+    const deleteStmt = this.db.prepare(`
+      DELETE FROM runtime_params
+      WHERE account IS ? AND param_key = ?
+    `);
+    deleteStmt.run(account, key);
+
+    this.recordRuntimeParamHistory({
+      account,
+      key,
+      oldValue: existing.param_value,
+      newValue: null,
+      source,
+      action: "clear",
+      isLocked: existing.is_locked,
+      expiresAt: existing.expires_at,
+      reason: options.reason ?? existing.reason ?? null,
+    });
+
+    return true;
+  }
+
+  /**
+   * List runtime parameter history/audit trail.
+   */
+  listRuntimeParamHistory(
+    options: {
+      account?: string | null;
+      key?: string;
+      limit?: number;
+    } = {}
+  ): RuntimeParamHistoryRecord[] {
+    const { account, key, limit = 50 } = options;
+    let query = `
+      SELECT id, timestamp, account, param_key, old_value, new_value, source, action, is_locked, expires_at, reason
+      FROM runtime_param_history
+      WHERE 1 = 1
+    `;
+    const params: any[] = [];
+
+    if (account === null) {
+      query += " AND account IS NULL";
+    } else if (account !== undefined) {
+      query += " AND account = ?";
+      params.push(account);
+    }
+
+    if (key) {
+      query += " AND param_key = ?";
+      params.push(key);
+    }
+
+    query += " ORDER BY timestamp DESC, id DESC LIMIT ?";
+    params.push(limit);
+
+    const rows = this.db.prepare(query).all(...params) as Array<{
+      id: number;
+      timestamp: number;
+      account: string | null;
+      param_key: string;
+      old_value: string | null;
+      new_value: string | null;
+      source: RuntimeParamSource;
+      action: "set" | "clear" | "expire";
+      is_locked: number | null;
+      expires_at: number | null;
+      reason: string | null;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      timestamp: row.timestamp,
+      account: row.account,
+      key: row.param_key,
+      oldValue: this.parseJsonSafe(row.old_value),
+      newValue: this.parseJsonSafe(row.new_value),
+      source: row.source,
+      action: row.action,
+      isLocked: row.is_locked === null ? null : row.is_locked === 1,
+      expiresAt: row.expires_at,
+      reason: row.reason,
+    }));
+  }
+
+  /**
    * Get or initialize strategy metrics for an account
    */
   getMetrics(account: string): {
@@ -1379,6 +1721,111 @@ export class MonitoringDatabase {
     }));
   }
 
+  private mapRuntimeParamRow(row: {
+    id: number;
+    account: string | null;
+    param_key: string;
+    param_value: string;
+    source: RuntimeParamSource;
+    is_locked: number;
+    updated_at: number;
+    expires_at: number | null;
+    reason: string | null;
+  }): RuntimeParamRecord {
+    return {
+      id: row.id,
+      account: row.account,
+      key: row.param_key,
+      value: this.parseJsonSafe(row.param_value),
+      source: row.source,
+      isLocked: row.is_locked === 1,
+      updatedAt: row.updated_at,
+      expiresAt: row.expires_at,
+      reason: row.reason,
+    };
+  }
+
+  private recordRuntimeParamHistory(params: {
+    account: string | null;
+    key: string;
+    oldValue: string | null;
+    newValue: string | null;
+    source: RuntimeParamSource;
+    action: "set" | "clear" | "expire";
+    isLocked: number | null;
+    expiresAt: number | null;
+    reason: string | null;
+  }): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO runtime_param_history (
+        timestamp, account, param_key, old_value, new_value, source, action, is_locked, expires_at, reason
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    stmt.run(
+      Date.now(),
+      params.account,
+      params.key,
+      params.oldValue,
+      params.newValue,
+      params.source,
+      params.action,
+      params.isLocked,
+      params.expiresAt,
+      params.reason
+    );
+  }
+
+  private cleanupExpiredRuntimeParams(account?: string | null): void {
+    let query = `
+      SELECT id, account, param_key, param_value, source, is_locked, expires_at, reason
+      FROM runtime_params
+      WHERE expires_at IS NOT NULL AND expires_at <= ?
+    `;
+    const params: any[] = [Date.now()];
+
+    if (account === null) {
+      query += " AND account IS NULL";
+    } else if (account !== undefined) {
+      query += " AND account = ?";
+      params.push(account);
+    }
+
+    const expiredRows = this.db.prepare(query).all(...params) as Array<{
+      id: number;
+      account: string | null;
+      param_key: string;
+      param_value: string;
+      source: RuntimeParamSource;
+      is_locked: number;
+      expires_at: number | null;
+      reason: string | null;
+    }>;
+
+    if (expiredRows.length === 0) {
+      return;
+    }
+
+    const deleteStmt = this.db.prepare(`DELETE FROM runtime_params WHERE id = ?`);
+    const cleanup = this.db.transaction(() => {
+      for (const row of expiredRows) {
+        this.recordRuntimeParamHistory({
+          account: row.account,
+          key: row.param_key,
+          oldValue: row.param_value,
+          newValue: null,
+          source: row.source,
+          action: "expire",
+          isLocked: row.is_locked,
+          expiresAt: row.expires_at,
+          reason: row.reason,
+        });
+        deleteStmt.run(row.id);
+      }
+    });
+    cleanup();
+  }
+
   /**
    * Normalize potentially mixed-scale USD values to 30 decimals.
    *
@@ -1406,6 +1853,18 @@ export class MonitoringDatabase {
       return BigInt(value);
     } catch {
       return 0n;
+    }
+  }
+
+  private parseJsonSafe(value: string | null): any {
+    if (value === null) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
     }
   }
 

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -495,6 +495,64 @@ const migration010_hedge_cost_columns: Migration = {
 };
 
 /**
+ * Migration: Add runtime strategy parameters and audit history
+ */
+const migration011_runtime_params: Migration = {
+  version: 11,
+  name: "runtime_params",
+  up: (db: Database.Database) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS runtime_params (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        account TEXT,
+        param_key TEXT NOT NULL,
+        param_value TEXT NOT NULL,
+        source TEXT NOT NULL CHECK(source IN ('manual', 'auto')),
+        is_locked INTEGER NOT NULL DEFAULT 0 CHECK(is_locked IN (0, 1)),
+        updated_at INTEGER NOT NULL,
+        expires_at INTEGER,
+        reason TEXT,
+        created_at INTEGER DEFAULT (strftime('%s', 'now')),
+        UNIQUE(account, param_key)
+      )
+    `);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS runtime_param_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp INTEGER NOT NULL,
+        account TEXT,
+        param_key TEXT NOT NULL,
+        old_value TEXT,
+        new_value TEXT,
+        source TEXT NOT NULL CHECK(source IN ('manual', 'auto')),
+        action TEXT NOT NULL CHECK(action IN ('set', 'clear', 'expire')),
+        is_locked INTEGER CHECK(is_locked IN (0, 1)),
+        expires_at INTEGER,
+        reason TEXT,
+        created_at INTEGER DEFAULT (strftime('%s', 'now'))
+      )
+    `);
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_runtime_params_account_key
+      ON runtime_params(account, param_key);
+      CREATE INDEX IF NOT EXISTS idx_runtime_params_expires
+      ON runtime_params(expires_at);
+      CREATE INDEX IF NOT EXISTS idx_runtime_param_history_account_key_time
+      ON runtime_param_history(account, param_key, timestamp DESC);
+    `);
+  },
+  down: (db: Database.Database) => {
+    db.exec(`DROP INDEX IF EXISTS idx_runtime_param_history_account_key_time`);
+    db.exec(`DROP INDEX IF EXISTS idx_runtime_params_expires`);
+    db.exec(`DROP INDEX IF EXISTS idx_runtime_params_account_key`);
+    db.exec(`DROP TABLE IF EXISTS runtime_param_history`);
+    db.exec(`DROP TABLE IF EXISTS runtime_params`);
+  },
+};
+
+/**
  * All migrations in order
  */
 export const migrations: Migration[] = [
@@ -508,6 +566,7 @@ export const migrations: Migration[] = [
   migration008_hedge_adjustments,
   migration009_wallet_balances,
   migration010_hedge_cost_columns,
+  migration011_runtime_params,
 ];
 
 /**

--- a/test/cli/commands/daemon.test.ts
+++ b/test/cli/commands/daemon.test.ts
@@ -107,6 +107,60 @@ vi.mock("../../../src/config/strategy", () => ({
   }),
 }));
 
+// Mock runtime config resolver
+vi.mock("../../../src/strategy/runtime-config", () => ({
+  loadEffectiveStrategyConfig: vi.fn().mockReturnValue({
+    config: {
+      optimizationDeltaThreshold: 0.1,
+      emergencyDeltaThreshold: 0.2,
+      minOptimizationInterval: 3600,
+      maxOptimizationInterval: 86400,
+      maxLeverage: 3.0,
+      minPositionSizeUsd: BigInt("10000000000000000000000000000"),
+      maxPositionSizeUsd: BigInt("50000000000000000000000000000"),
+      maxSlippage: 0.01,
+      slippageBuffer: 0.005,
+      minOptimizationFeeThresholdUsd: BigInt("5000000000000000000000000000"),
+      defaultExecutionFee: BigInt("1000000000000000"),
+      estimatedOptimizationGasCostUsd: BigInt("2000000000000000000000000000"),
+      rangeAdjustmentThreshold: 0.15,
+      rangeCenterDriftThreshold: 0.02,
+      defaultRangeWidth: 0.06,
+      minRangeWidth: 0.04,
+      maxRangeWidth: 0.4,
+      targetLeverage: 3.0,
+      minOptimizationBenefitRatio: 1.5,
+      hedgeDeltaThreshold: 0.05,
+      minHedgeInterval: 300,
+      minHedgeAdjustmentUsd: BigInt("5000000000000000000000000000000"),
+      maxHedgeLeverage: 10.0,
+    },
+    appliedParams: [],
+    globalParams: [],
+    accountParams: [],
+  }),
+  diffStrategyConfigs: vi.fn().mockReturnValue([]),
+}));
+
+// Mock auto tuner
+vi.mock("../../../src/strategy/auto-tuner", () => ({
+  runAutoTuner: vi.fn().mockReturnValue({
+    enabled: false,
+    applied: false,
+    regime: "normal",
+    candidateRegime: "normal",
+    metrics: {
+      volatility1h: 0,
+      volatility24h: 0,
+      outOfRangeFrequency24h: 0,
+      hedgeAdjustmentsPerHour: 0,
+      optimizationsPerHour: 0,
+      feeToCostRatio24h: 0,
+    },
+    changes: [],
+  }),
+}));
+
 // Mock addresses
 vi.mock("../../../src/config/addresses", () => ({
   ARBITRUM_MAINNET: {
@@ -125,6 +179,7 @@ const mockCheckFn = vi.fn();
 vi.mock("../../../src/strategy/monitor", () => ({
   DeltaNeutralMonitor: vi.fn().mockImplementation(() => ({
     check: mockCheckFn,
+    setConfig: vi.fn(),
   })),
 }));
 
@@ -307,6 +362,48 @@ describe("daemon command", () => {
     expect(snapshot).not.toBeNull();
     expect(snapshot!.account).toBe("0x1234567890123456789012345678901234567890");
     expect(snapshot!.recommendationAction).toBe(StrategyAction.NONE);
+  });
+
+  it("should hot-reload runtime config changes without restart", async () => {
+    const status = createMockStatus();
+    const recommendation = createMockRecommendation();
+    mockCheckFn.mockResolvedValue({ status, recommendation });
+
+    const { diffStrategyConfigs } = await import("../../../src/strategy/runtime-config");
+    vi.mocked(diffStrategyConfigs)
+      .mockReturnValueOnce([
+        {
+          key: "defaultRangeWidth",
+          before: "0.06",
+          after: "0.08",
+        },
+      ] as any)
+      .mockReturnValue([]);
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+
+    const daemonPromise = daemon({
+      account: "0x1234567890123456789012345678901234567890",
+      interval: 1,
+      dbPath: testDbPath,
+    }).catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const { DeltaNeutralMonitor } = await import("../../../src/strategy/monitor");
+    const monitorInstance = vi.mocked(DeltaNeutralMonitor).mock.results[0]?.value as {
+      setConfig: ReturnType<typeof vi.fn>;
+    };
+
+    expect(monitorInstance.setConfig).toHaveBeenCalled();
+
+    process.emit("SIGINT" as any, "SIGINT");
+    await vi.advanceTimersByTimeAsync(100);
+    await daemonPromise;
+    exitSpy.mockRestore();
   });
 
   it("should handle errors gracefully with exponential backoff", async () => {
@@ -659,11 +756,13 @@ describe("daemon command", () => {
 
       // Verify optimization was called
       const { executeOptimize: executeOptimizeFn } = await import("../../../src/cli/commands/strategy/execute-optimize");
-      expect(executeOptimizeFn).toHaveBeenCalledWith({
-        account: "0x1234567890123456789012345678901234567890",
-        execute: true,
-        suppressAlert: true,
-      });
+      expect(executeOptimizeFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: "0x1234567890123456789012345678901234567890",
+          execute: true,
+          suppressAlert: true,
+        })
+      );
 
       const { sendSuccessAlert } = await import("../../../src/utils/alerts");
       expect(sendSuccessAlert).toHaveBeenCalledWith(

--- a/test/cli/commands/strategy.test.ts
+++ b/test/cli/commands/strategy.test.ts
@@ -47,5 +47,6 @@ describe("Strategy Commands", () => {
     expect(subcommands).toContain("monitor");
     expect(subcommands).toContain("optimize");
     expect(subcommands).toContain("close");
+    expect(subcommands).toContain("params");
   });
 });

--- a/test/cli/commands/strategy/execute-hedge-adjust.test.ts
+++ b/test/cli/commands/strategy/execute-hedge-adjust.test.ts
@@ -112,11 +112,25 @@ vi.mock("../../../../src/modules/gmx/orders", () => ({
 }));
 
 vi.mock("../../../../src/config/strategy", () => ({
+  DEFAULT_STRATEGY_CONFIG: {
+    defaultRangeWidth: 0.06,
+    minRangeWidth: 0.04,
+    maxRangeWidth: 0.4,
+  },
   loadStrategyConfig: vi.fn(() => ({
     maxSlippage: 0.01,
     slippageBuffer: 0.005,
+    defaultRangeWidth: 0.06,
+    minRangeWidth: 0.04,
+    maxRangeWidth: 0.4,
+    rangeAdjustmentThreshold: 0.15,
+    rangeCenterDriftThreshold: 0.02,
+    hedgeDeltaThreshold: 0.05,
+    optimizationDeltaThreshold: 0.1,
+    emergencyDeltaThreshold: 0.2,
     defaultExecutionFee: 1000000000000000n,
   })),
+  validateStrategyConfig: vi.fn(),
 }));
 
 vi.mock("../../../../src/utils/database", () => ({

--- a/test/cli/commands/strategy/execute-optimize-runtime.test.ts
+++ b/test/cli/commands/strategy/execute-optimize-runtime.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveOptimizationRangeWidth } from "../../../../src/strategy/optimize-defaults";
+import { DEFAULT_STRATEGY_CONFIG } from "../../../../src/config/strategy";
+
+describe("executeOptimize runtime defaults", () => {
+  it("uses effective runtime config range width when override is omitted", () => {
+    const runtimeConfig = {
+      ...DEFAULT_STRATEGY_CONFIG,
+      defaultRangeWidth: 0.11,
+    };
+
+    const rangeWidth = resolveOptimizationRangeWidth(undefined, runtimeConfig);
+    expect(rangeWidth).toBe(0.11);
+  });
+
+  it("prioritizes explicit --range-width over runtime config", () => {
+    const runtimeConfig = {
+      ...DEFAULT_STRATEGY_CONFIG,
+      defaultRangeWidth: 0.11,
+    };
+
+    const rangeWidth = resolveOptimizationRangeWidth(0.2, runtimeConfig);
+    expect(rangeWidth).toBe(0.2);
+  });
+});

--- a/test/cli/commands/strategy/params.test.ts
+++ b/test/cli/commands/strategy/params.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+
+vi.mock("../../../../src/cli/commands/base", () => ({
+  getSignerAndAccount: vi.fn().mockResolvedValue({
+    signer: {},
+    account: "0x1234567890123456789012345678901234567890",
+  }),
+}));
+
+import {
+  clearStrategyParam,
+  setAutoTuning,
+  setStrategyParam,
+} from "../../../../src/cli/commands/strategy/params";
+import { MonitoringDatabase } from "../../../../src/utils/database";
+import { getRuntimeControlValue, loadEffectiveStrategyConfig } from "../../../../src/strategy/runtime-config";
+
+describe("strategy params commands", () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(
+      process.cwd(),
+      "test-data",
+      `strategy-params-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    );
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(dbPath)) {
+      fs.unlinkSync(dbPath);
+    }
+  });
+
+  it("set updates effective runtime config", async () => {
+    await setStrategyParam({
+      account: "0x1234567890123456789012345678901234567890",
+      key: "defaultRangeWidth",
+      value: "0.08",
+      dbPath,
+    });
+
+    const db = new MonitoringDatabase(dbPath);
+    const effective = loadEffectiveStrategyConfig(
+      db,
+      "0x1234567890123456789012345678901234567890"
+    ).config;
+    expect(effective.defaultRangeWidth).toBe(0.08);
+    db.close();
+  });
+
+  it("clear removes runtime override", async () => {
+    await setStrategyParam({
+      account: "0x1234567890123456789012345678901234567890",
+      key: "hedgeDeltaThreshold",
+      value: "0.04",
+      dbPath,
+    });
+
+    await clearStrategyParam({
+      account: "0x1234567890123456789012345678901234567890",
+      key: "hedgeDeltaThreshold",
+      dbPath,
+    });
+
+    const db = new MonitoringDatabase(dbPath);
+    const effective = loadEffectiveStrategyConfig(
+      db,
+      "0x1234567890123456789012345678901234567890"
+    ).config;
+    expect(effective.hedgeDeltaThreshold).toBe(0.05);
+    db.close();
+  });
+
+  it("auto command toggles auto-tuner runtime flag", async () => {
+    await setAutoTuning({
+      account: "0x1234567890123456789012345678901234567890",
+      enable: true,
+      dbPath,
+    });
+
+    const db = new MonitoringDatabase(dbPath);
+    const enabled = getRuntimeControlValue<boolean>(
+      db,
+      "autoTuningEnabled",
+      "0x1234567890123456789012345678901234567890"
+    );
+
+    expect(enabled).toBe(true);
+    db.close();
+  });
+});

--- a/test/config/range-optimization.test.ts
+++ b/test/config/range-optimization.test.ts
@@ -90,21 +90,17 @@ describe("Range Configuration Optimization (Issue #41)", () => {
   });
 
   describe("Range Adjustment Thresholds", () => {
-    it("should have appropriate adjustment thresholds for ±7.5% range", () => {
+    it("should have proactive adjustment thresholds for 6% default width", () => {
       const { rangeAdjustmentThreshold, rangeCenterDriftThreshold, defaultRangeWidth } =
         DEFAULT_STRATEGY_CONFIG;
 
-      // Edge threshold: 2% - adjust when within 2% of range edge
-      // For ±7.5% range, this means adjusting when price is within ~13% of range width
-      expect(rangeAdjustmentThreshold).toBe(0.02);
+      // Edge threshold: 15% of range span from the nearest edge
+      expect(rangeAdjustmentThreshold).toBe(0.15);
 
-      // Center drift threshold: 5% - adjust when price drifts >5% from center
-      // This is ~33% of the half-width (7.5%), which is reasonable
-      expect(rangeCenterDriftThreshold).toBe(0.05);
+      // Center drift threshold must stay strictly below half-width for proactive recentering
+      expect(rangeCenterDriftThreshold).toBe(0.02);
 
-      // Thresholds should be proportional to range width
-      // Edge threshold should be less than half the range width
-      expect(rangeAdjustmentThreshold * 2).toBeLessThan(defaultRangeWidth);
+      expect(rangeCenterDriftThreshold).toBeLessThan(defaultRangeWidth / 2);
     });
 
     it("should allow environment variable overrides for thresholds", () => {

--- a/test/config/strategy.test.ts
+++ b/test/config/strategy.test.ts
@@ -196,6 +196,23 @@ describe("Strategy Configuration", () => {
       expect(() => validateStrategyConfig(invalid)).toThrow();
     });
 
+    it("should reject max range width >= 1", () => {
+      const invalid = {
+        ...DEFAULT_STRATEGY_CONFIG,
+        maxRangeWidth: 1.0,
+      };
+      expect(() => validateStrategyConfig(invalid)).toThrow(/maxRangeWidth/);
+    });
+
+    it("should reject range center drift threshold outside half-width", () => {
+      const invalid = {
+        ...DEFAULT_STRATEGY_CONFIG,
+        defaultRangeWidth: 0.06,
+        rangeCenterDriftThreshold: 0.03,
+      };
+      expect(() => validateStrategyConfig(invalid)).toThrow(/rangeCenterDriftThreshold/);
+    });
+
     it("should reject zero or negative bigint values", () => {
       const invalid = {
         ...DEFAULT_STRATEGY_CONFIG,

--- a/test/strategy/auto-tuner.test.ts
+++ b/test/strategy/auto-tuner.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+import { MonitoringDatabase } from "../../src/utils/database";
+import { runAutoTuner } from "../../src/strategy/auto-tuner";
+import { loadEffectiveStrategyConfig, setRuntimeControlValue } from "../../src/strategy/runtime-config";
+
+describe("auto-tuner", () => {
+  let db: MonitoringDatabase;
+  let dbPath: string;
+  const account = "0x1234567890123456789012345678901234567890";
+
+  beforeEach(() => {
+    dbPath = path.join(
+      process.cwd(),
+      "test-data",
+      `auto-tuner-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    );
+    db = new MonitoringDatabase(dbPath);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(dbPath)) {
+      fs.unlinkSync(dbPath);
+    }
+  });
+
+  function insertSnapshot(params: {
+    timestamp: number;
+    price: number;
+    outOfRange?: boolean;
+  }): void {
+    const insertSnapshot = db.getDb().prepare(`
+      INSERT INTO monitoring_snapshots (
+        timestamp, account, total_nav_usd, total_lp_value_usd, gmx_net_value_usd,
+        total_lp_delta, gmx_delta, net_delta, delta_drift, total_fees_usd,
+        wallet_eth_usd, wallet_weth_usd, wallet_usdc_usd,
+        recommendation_action, recommendation_reason
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = insertSnapshot.run(
+      params.timestamp,
+      account,
+      "1000000000000000000000000000000",
+      "700000000000000000000000000000",
+      "300000000000000000000000000000",
+      "1000000000000000000",
+      "-1000000000000000000",
+      "0",
+      0.0,
+      "1000000000000000000000000000",
+      "0",
+      "0",
+      "0",
+      "NONE",
+      params.outOfRange ? "One or more positions are out of range" : "Strategy is healthy"
+    );
+
+    const snapshotId = Number(result.lastInsertRowid);
+
+    db.getDb()
+      .prepare(
+        `
+      INSERT INTO position_snapshots (
+        snapshot_id, token_id, position_type, current_price, delta
+      ) VALUES (?, ?, 'uniswap', ?, ?)
+    `
+      )
+      .run(snapshotId, "123", params.price, "1000000000000000000");
+  }
+
+  it("applies regime changes with hysteresis and step-size caps", () => {
+    const now = Date.now();
+
+    setRuntimeControlValue({
+      db,
+      account,
+      key: "autoTuningEnabled",
+      value: true,
+      source: "manual",
+      isLocked: true,
+    });
+
+    // 10 snapshots in the last hour, one out-of-range => 10% frequency => volatile regime
+    for (let i = 0; i < 10; i++) {
+      insertSnapshot({
+        timestamp: now - (10 - i) * 5 * 60 * 1000,
+        price: 2000,
+        outOfRange: i === 2,
+      });
+    }
+
+    const effectiveBefore = loadEffectiveStrategyConfig(db, account).config;
+
+    const firstRun = runAutoTuner({
+      db,
+      account,
+      effectiveConfig: effectiveBefore,
+      now,
+    });
+
+    expect(firstRun.enabled).toBe(true);
+    expect(firstRun.candidateRegime).toBe("volatile");
+    expect(firstRun.applied).toBe(false);
+
+    const secondRun = runAutoTuner({
+      db,
+      account,
+      effectiveConfig: loadEffectiveStrategyConfig(db, account).config,
+      now: now + 1,
+    });
+
+    expect(secondRun.applied).toBe(true);
+    expect(secondRun.regime).toBe("volatile");
+
+    const widthParam = db.getRuntimeParam(account, "defaultRangeWidth");
+    expect(widthParam).not.toBeNull();
+    // Step cap is 0.02 from default 0.06 toward volatile target 0.10.
+    expect(widthParam?.value).toBeCloseTo(0.08, 8);
+  });
+
+  it("does not override manually locked parameters", () => {
+    const now = Date.now();
+
+    setRuntimeControlValue({
+      db,
+      account,
+      key: "autoTuningEnabled",
+      value: true,
+      source: "manual",
+      isLocked: true,
+    });
+
+    db.setRuntimeParam(account, "defaultRangeWidth", 0.07, {
+      source: "manual",
+      isLocked: true,
+      reason: "manual lock",
+    });
+
+    // High out-of-range frequency => extreme regime
+    for (let i = 0; i < 10; i++) {
+      insertSnapshot({
+        timestamp: now - (10 - i) * 5 * 60 * 1000,
+        price: 2000,
+        outOfRange: i < 3,
+      });
+    }
+
+    runAutoTuner({
+      db,
+      account,
+      effectiveConfig: loadEffectiveStrategyConfig(db, account).config,
+      now,
+    });
+
+    const secondRun = runAutoTuner({
+      db,
+      account,
+      effectiveConfig: loadEffectiveStrategyConfig(db, account).config,
+      now: now + 1,
+    });
+
+    const widthChange = secondRun.changes.find((change) => change.key === "defaultRangeWidth");
+    expect(widthChange).toBeDefined();
+    expect(widthChange?.skipped).toBe(true);
+    expect(widthChange?.reason).toBe("manual-lock");
+
+    const widthParam = db.getRuntimeParam(account, "defaultRangeWidth");
+    expect(widthParam?.value).toBe(0.07);
+    expect(widthParam?.source).toBe("manual");
+  });
+});

--- a/test/strategy/monitor.test.ts
+++ b/test/strategy/monitor.test.ts
@@ -281,6 +281,44 @@ describe("DeltaNeutralMonitor", () => {
     expect(result.recommendation.action).toBe(StrategyAction.OPTIMIZE);
   });
 
+  it("should proactively recommend OPTIMIZE when price is near range edge under default width", async () => {
+    // Keep total width near default (~6%) but shift center so current price is near upper edge.
+    // This should trigger the near-edge threshold (15% of span) before going out of range.
+    const nearEdgePos = {
+      ...mockUniswapPosition,
+      tickLower: 69080 - 550,
+      tickUpper: 69080 + 50,
+      tokensOwed0: 6000000n, // Ensure range issue is economically actionable
+    };
+
+    vi.mocked(uniswapReader.getPosition).mockResolvedValue(nearEdgePos);
+    vi.mocked(uniswapReader.getPositionWithFees).mockResolvedValue(nearEdgePos);
+    vi.mocked(uniswapReader.getActivePositionsForOwner).mockResolvedValue([
+      { tokenId: 123n, position: nearEdgePos },
+    ]);
+
+    // First compute LP delta, then set GMX to perfect hedge so range logic drives recommendation.
+    vi.mocked(gmxReader.getPosition).mockResolvedValue(undefined);
+    const initialResult = await monitor.check();
+    const lpDelta = initialResult.status.totalLpDelta;
+
+    vi.mocked(gmxReader.getPosition).mockResolvedValue({
+      addresses: {} as any,
+      numbers: {
+        sizeInTokens: lpDelta,
+        collateralAmount: 0n,
+        sizeInUsd: 0n,
+        shortTokenClaimableFundingAmountPerSize: 0n,
+      } as any,
+      flags: { isLong: false },
+    });
+
+    const result = await monitor.check();
+
+    expect(result.recommendation.action).toBe(StrategyAction.OPTIMIZE);
+    expect(result.recommendation.reason).toContain("edge");
+  });
+
   describe("token metadata caching", () => {
     it("should cache token metadata after first check()", async () => {
       const mockPoolContract = {

--- a/test/strategy/runtime-config.test.ts
+++ b/test/strategy/runtime-config.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+import { MonitoringDatabase } from "../../src/utils/database";
+import {
+  clearRuntimeStrategyParam,
+  getRuntimeControlValue,
+  loadEffectiveStrategyConfig,
+  setRuntimeControlValue,
+  setRuntimeStrategyParam,
+} from "../../src/strategy/runtime-config";
+
+describe("runtime-config", () => {
+  let db: MonitoringDatabase;
+  let dbPath: string;
+  const account = "0x1234567890123456789012345678901234567890";
+
+  beforeEach(() => {
+    dbPath = path.join(
+      process.cwd(),
+      "test-data",
+      `runtime-config-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    );
+    db = new MonitoringDatabase(dbPath);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(dbPath)) {
+      fs.unlinkSync(dbPath);
+    }
+  });
+
+  it("applies account overrides over global overrides over defaults", () => {
+    db.setRuntimeParam(null, "defaultRangeWidth", 0.08, {
+      source: "manual",
+      isLocked: true,
+    });
+    db.setRuntimeParam(account, "defaultRangeWidth", 0.1, {
+      source: "manual",
+      isLocked: true,
+    });
+
+    const accountEffective = loadEffectiveStrategyConfig(db, account).config;
+    const globalEffective = loadEffectiveStrategyConfig(db).config;
+
+    expect(globalEffective.defaultRangeWidth).toBe(0.08);
+    expect(accountEffective.defaultRangeWidth).toBe(0.1);
+  });
+
+  it("validates full strategy invariants on runtime updates", () => {
+    expect(() =>
+      setRuntimeStrategyParam({
+        db,
+        account,
+        key: "rangeCenterDriftThreshold",
+        value: 0.04,
+      })
+    ).toThrow(/half of defaultRangeWidth/);
+  });
+
+  it("clears runtime strategy parameters and restores effective defaults", () => {
+    setRuntimeStrategyParam({
+      db,
+      account,
+      key: "hedgeDeltaThreshold",
+      value: 0.04,
+    });
+
+    let effective = loadEffectiveStrategyConfig(db, account).config;
+    expect(effective.hedgeDeltaThreshold).toBe(0.04);
+
+    const clearResult = clearRuntimeStrategyParam({
+      db,
+      account,
+      key: "hedgeDeltaThreshold",
+    });
+
+    expect(clearResult.cleared).toBe(true);
+    effective = loadEffectiveStrategyConfig(db, account).config;
+    expect(effective.hedgeDeltaThreshold).toBe(0.05);
+  });
+
+  it("resolves runtime control flags with account precedence", () => {
+    setRuntimeControlValue({
+      db,
+      account: null,
+      key: "autoTuningEnabled",
+      value: false,
+      source: "manual",
+      isLocked: true,
+    });
+    setRuntimeControlValue({
+      db,
+      account,
+      key: "autoTuningEnabled",
+      value: true,
+      source: "manual",
+      isLocked: true,
+    });
+
+    const accountValue = getRuntimeControlValue<boolean>(db, "autoTuningEnabled", account);
+    const globalValue = getRuntimeControlValue<boolean>(db, "autoTuningEnabled");
+
+    expect(globalValue).toBe(false);
+    expect(accountValue).toBe(true);
+  });
+});

--- a/test/utils/database.test.ts
+++ b/test/utils/database.test.ts
@@ -966,6 +966,82 @@ describe("MonitoringDatabase", () => {
     });
   });
 
+  describe("runtime params", () => {
+    it("should set and get runtime params with metadata", () => {
+      const account = "0x1234567890123456789012345678901234567890";
+      const expiresAt = Date.now() + 60_000;
+
+      const result = db.setRuntimeParam(account, "defaultRangeWidth", 0.08, {
+        source: "manual",
+        isLocked: true,
+        reason: "operator override",
+        expiresAt,
+      });
+
+      expect(result.applied).toBe(true);
+
+      const runtimeParam = db.getRuntimeParam(account, "defaultRangeWidth");
+      expect(runtimeParam).not.toBeNull();
+      expect(runtimeParam?.value).toBe(0.08);
+      expect(runtimeParam?.source).toBe("manual");
+      expect(runtimeParam?.isLocked).toBe(true);
+      expect(runtimeParam?.reason).toBe("operator override");
+      expect(runtimeParam?.expiresAt).toBe(expiresAt);
+    });
+
+    it("should return global + account params in one snapshot call", () => {
+      const account = "0x1234567890123456789012345678901234567890";
+      db.setRuntimeParam(null, "defaultRangeWidth", 0.07, { source: "manual", isLocked: true });
+      db.setRuntimeParam(account, "defaultRangeWidth", 0.09, {
+        source: "manual",
+        isLocked: true,
+      });
+
+      const snapshot = db.getRuntimeParamSnapshot(account);
+      expect(snapshot.globalParams).toHaveLength(1);
+      expect(snapshot.accountParams).toHaveLength(1);
+      expect(snapshot.globalParams[0].value).toBe(0.07);
+      expect(snapshot.accountParams[0].value).toBe(0.09);
+    });
+
+    it("should prevent auto updates from overwriting manual locks", () => {
+      const account = "0x1234567890123456789012345678901234567890";
+      db.setRuntimeParam(account, "defaultRangeWidth", 0.08, {
+        source: "manual",
+        isLocked: true,
+      });
+
+      const autoUpdate = db.setRuntimeParam(account, "defaultRangeWidth", 0.12, {
+        source: "auto",
+        isLocked: false,
+      });
+
+      expect(autoUpdate.applied).toBe(false);
+      expect(autoUpdate.reason).toBe("manual-lock");
+      expect(db.getRuntimeParam(account, "defaultRangeWidth")?.value).toBe(0.08);
+    });
+
+    it("should record runtime param history for set and clear", () => {
+      const account = "0x1234567890123456789012345678901234567890";
+      db.setRuntimeParam(account, "hedgeDeltaThreshold", 0.04, {
+        source: "manual",
+        isLocked: true,
+      });
+      db.clearRuntimeParam(account, "hedgeDeltaThreshold");
+
+      const history = db.listRuntimeParamHistory({
+        account,
+        key: "hedgeDeltaThreshold",
+        limit: 10,
+      });
+
+      expect(history.length).toBeGreaterThanOrEqual(2);
+      expect(history[0].action).toBe("clear");
+      expect(history[1].action).toBe("set");
+      expect(history[1].newValue).toBe(0.04);
+    });
+  });
+
   describe("strategy metrics", () => {
     it("should initialize metrics on first access", () => {
       const account = "0x1234567890123456789012345678901234567890";

--- a/test/utils/migrations.test.ts
+++ b/test/utils/migrations.test.ts
@@ -82,6 +82,8 @@ describe("Database Migrations", () => {
       expect(tableNames).toContain("monitoring_snapshots");
       expect(tableNames).toContain("position_snapshots");
       expect(tableNames).toContain("nav_history");
+      expect(tableNames).toContain("runtime_params");
+      expect(tableNames).toContain("runtime_param_history");
       expect(tableNames).toContain("schema_migrations");
     });
 


### PR DESCRIPTION
## Summary
- add DB-backed runtime strategy parameters with scoped precedence (`account > global > env/default`) and full audit history
- add runtime config resolver service and wire hot-reload into daemon/monitor/dashboard/report/strategy flows
- add regime-based auto-tuner with hysteresis, step-size caps, invariants, and manual-lock protection
- add `strategy params` CLI (`show`, `set`, `clear`, `history`, `auto`) for live operator control
- update optimize defaults to use effective runtime width when `--range-width` is omitted
- refresh docs (`AGENTS.md`, `docs/CLI.md`, `docs/DATABASE.md`) for runtime param operations and source of truth

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

## Notes
- includes migration for `runtime_params` and `runtime_param_history`
- includes comprehensive unit/integration/regression tests for precedence, validation, hot reload, auto-tuning transitions, CLI behavior, and optimize-width defaulting

Closes #98
